### PR TITLE
Fix support for psc1 and ps1xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.0 - TBD
 
 * Added support for `.dll` and `.exe` files through the `PEBinary` provider
+* Fixed up support for PowerShell XML signatures for `.psc1`, `.ps1xml`
 * Output nested signatures when a file has been signed with multiple hash algorithms
 * Renamed output property `HashAlgorithmName` to just `HashAlgorithm`
 * Added the following cmdlets

--- a/OpenAuthenticode.build.ps1
+++ b/OpenAuthenticode.build.ps1
@@ -90,21 +90,25 @@ task Sign {
         return
     }
 
+    Import-Module -Name (Join-Path $ReleasePath "$ModuleName.psd1") -ErrorAction Stop
+
     [byte[]]$certBytes = [System.Convert]::FromBase64String($env:PSMODULE_SIGNING_CERT)
     $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certBytes, $certPassword)
     $signParams = @{
         Certificate = $cert
-        TimestampServer = 'http://timestamp.digicert.com'
+        TimeStampServer = 'http://timestamp.digicert.com'
         HashAlgorithm = 'SHA256'
     }
 
     Get-ChildItem -LiteralPath $ReleasePath -Recurse -ErrorAction SilentlyContinue |
-        Where-Object Extension -In ".ps1", ".psm1", ".psd1", ".ps1xml", ".dll" |
+        Where-Object {
+            $_.Extension -in ".ps1", ".psm1", ".psd1", ".ps1xml" -or (
+                $_.Extension -eq ".dll" -and $_.BaseName -like "$ModuleName*"
+            )
+        } |
         ForEach-Object -Process {
-            $result = Set-AuthenticodeSignature -LiteralPath $_.FullName @signParams
-            if ($result.Status -ne "Valid") {
-                throw "Failed to sign $($_.FullName) - Status: $($result.Status) Message: $($result.StatusMessage)"
-            }
+            Write-Host $_.FullName
+            Set-OpenAuthenticodeSignature -LiteralPath $_.FullName @signParams
         }
 }
 

--- a/docs/en-US/Add-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Add-OpenAuthenticodeSignature.md
@@ -258,6 +258,7 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
+* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml

--- a/docs/en-US/Clear-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Clear-OpenAuthenticodeSignature.md
@@ -126,6 +126,7 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
+* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml

--- a/docs/en-US/Get-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Get-OpenAuthenticodeSignature.md
@@ -197,6 +197,7 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
+* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml

--- a/docs/en-US/Set-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Set-OpenAuthenticodeSignature.md
@@ -265,6 +265,7 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
+* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml

--- a/docs/en-US/about_AuthenticodeProviders.md
+++ b/docs/en-US/about_AuthenticodeProviders.md
@@ -10,7 +10,8 @@ Currently the following providers have been implemented in this module.
 
 |Provider|File Extensions|String Contents|
 |-|-|-|
-|PowerShell|`.ps1`, `.psc1`, `.psd1`, `.psm1`, `.ps1xml`|Yes|
+|PowerShell|`.ps1`, `.psd1`, `.psm1`|Yes|
+|PowerShellXml|`.psc1`, `.ps1xml`|Yes|
 |PEBinary|`.dll`, `.exe`|No|
 
 The `Get-OpenAuthenticodeSignature` and `Set-OpenAuthenticodeSignature` uses the extension on the file path provided to determine what provider to use.

--- a/src/OpenAuthenticode/IAuthenticodeProvider.cs
+++ b/src/OpenAuthenticode/IAuthenticodeProvider.cs
@@ -67,6 +67,9 @@ internal static class ProviderFactory
         RegisterProvider(AuthenticodeProvider.PowerShell,
             PowerShellScriptProvider.FileExtensions,
             PowerShellScriptProvider.Create);
+        RegisterProvider(AuthenticodeProvider.PowerShellXml,
+            PowerShellXmlProvider.FileExtensions,
+            PowerShellXmlProvider.Create);
     }
 
     /// <summary>
@@ -147,5 +150,6 @@ public enum AuthenticodeProvider
 {
     NotSpecified,
     PowerShell,
+    PowerShellXml,
     PEBinary,
 }

--- a/tests/PowerShell.Tests.ps1
+++ b/tests/PowerShell.Tests.ps1
@@ -37,6 +37,29 @@ Describe "PowerShell Authenticode" {
         }
     }
 
+    It "Signs ps1xml script" {
+        $scriptPath = New-Item -Path temp: -Name script.ps1xml -Force -Value "<?xml version=`"1.0`" encoding=`"utf-8`"?>`n<Configuration />"
+
+        $setParams = @{
+            Path = $scriptPath
+            Certificate = $cert
+        }
+        $res = Set-OpenAuthenticodeSignature @setParams
+        $res | Should -BeNullOrEmpty
+
+        $actual = Get-OpenAuthenticodeSignature -Path $scriptPath @trustParams
+        $actual | Should -BeOfType ([System.Security.Cryptography.Pkcs.SignedCms])
+        $actual.Path | Should -Be $scriptPath.FullName
+        $actual.HashAlgorithm | Should -Be SHA256
+        $actual.TimeStampInfo | Should -BeNullOrEmpty
+        $actual.Certificate.Thumbprint | Should -Be $cert.Thumbprint
+
+        If (Get-Command -Name Get-AuthenticodeSignature -ErrorAction Ignore) {
+            $actual = Get-AuthenticodeSignature -FilePath $scriptPath.FullName
+            $actual.Status | Should -Not -Be HashMismatch
+        }
+    }
+
     It "Signs and adds a signature" {
         $scriptPath = New-Item -Path temp: -Name script.ps1 -Force -Value "Write-Host test`r`n"
 


### PR DESCRIPTION
Fixes support for XML based PowerShell files like ps1xml and psc1 by including them in a custom provider. Also moves the build process to use the new module instead of Set-AuthenticodeSignature on Windows.