### PR TITLE
Added -Silent parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Reworked Assembly Load Context to properly store extra dlls in new ALC
 * Added `Get-OpenAuthenticodeSslDotComKey` which can use SSL.com's eSigner API to sign content
+* Added the `-Silent` parameter for `Set-OpenAuthenticodeSignature` and `Add-OpenAuthenticodeSignature` to disable Windows certificate PIN prompts
+  * The original behaviour was to always be silent but has been changed, use this parameter to fallback to the old behaviour.
 
 ## v0.2.0 - 2023-03-25
 

--- a/docs/en-US/Add-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Add-OpenAuthenticodeSignature.md
@@ -16,32 +16,32 @@ Adds an authenticode signature to a file.
 ```
 Add-OpenAuthenticodeSignature [-Path] <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PathKey
 ```
 Add-OpenAuthenticodeSignature [-Path] <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathCertificate
 ```
 Add-OpenAuthenticodeSignature -LiteralPath <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathKey
 ```
 Add-OpenAuthenticodeSignature -LiteralPath <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -266,6 +266,23 @@ Type: AuthenticodeProvider
 Parameter Sets: (All)
 Aliases:
 Accepted values: NotSpecified, PowerShell, PowerShellXml, PEBinary
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Silent
+Do not show any PIN prompts when attempting to open the key for signing.
+If a key requires a PIN prompt and `-Silent` is specified, the signing operation will fail.
+This is only valid for keys retrieved by Windows and is ignored by custom keys provided with `-Key`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/en-US/Set-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Set-OpenAuthenticodeSignature.md
@@ -16,32 +16,32 @@ Set an authenticode signature on a file.
 ```
 Set-OpenAuthenticodeSignature [-Path] <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PathKey
 ```
 Set-OpenAuthenticodeSignature [-Path] <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathCertificate
 ```
 Set-OpenAuthenticodeSignature -LiteralPath <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathKey
 ```
 Set-OpenAuthenticodeSignature -LiteralPath <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
- [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
+ [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -273,6 +273,23 @@ Type: AuthenticodeProvider
 Parameter Sets: (All)
 Aliases:
 Accepted values: NotSpecified, PowerShell, PowerShellXml, PEBinary
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Silent
+Do not show any PIN prompts when attempting to open the key for signing.
+If a key requires a PIN prompt and `-Silent` is specified, the signing operation will fail.
+This is only valid for keys retrieved by Windows and is ignored by custom keys provided with `-Key`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/src/OpenAuthenticode.Module/OpenAuthenticodeSignature.cs
+++ b/src/OpenAuthenticode.Module/OpenAuthenticodeSignature.cs
@@ -463,6 +463,9 @@ public abstract class AddSetOpenAuthenticodeSignature : OpenAuthenticodeSignatur
     [Parameter()]
     public string? TimeStampServer { get; set; }
 
+    [Parameter()]
+    public SwitchParameter Silent { get; set; }
+
     protected abstract bool Append { get; }
 
     protected override async Task ProcessRecordAsync()
@@ -547,7 +550,8 @@ public abstract class AddSetOpenAuthenticodeSignature : OpenAuthenticodeSignatur
                         IncludeOption,
                         captureKey,
                         null,
-                        null);
+                        null,
+                        true);
                 }
                 catch (CapturedHashException e)
                 {
@@ -591,7 +595,8 @@ public abstract class AddSetOpenAuthenticodeSignature : OpenAuthenticodeSignatur
                     IncludeOption,
                     Key?.Key,
                     TimeStampServer,
-                    TimeStampHashAlgorithm);
+                    TimeStampHashAlgorithm,
+                    Silent);
                 SignatureHelper.SetFileSignature(
                     operation.Provider,
                     signInfo,

--- a/src/OpenAuthenticode/SignatureHelper.cs
+++ b/src/OpenAuthenticode/SignatureHelper.cs
@@ -105,7 +105,8 @@ public static class SignatureHelper
         X509IncludeOption includeOption,
         AsymmetricAlgorithm? privateKey,
         string? timestampServer,
-        HashAlgorithmName? timestampAlgorithm
+        HashAlgorithmName? timestampAlgorithm,
+        bool silent
     )
     {
         Oid digestOid = SpcIndirectData.OidFromHashAlgorithm(hashAlgorithm);
@@ -120,7 +121,7 @@ public static class SignatureHelper
         }
 
         SignedCms signInfo = new(dataToSign, false);
-        signInfo.ComputeSignature(signer, true);
+        signInfo.ComputeSignature(signer, silent);
 
         if (!string.IsNullOrWhiteSpace(timestampServer))
         {


### PR DESCRIPTION
Changes the default behaviour of signing certificates from the Windows key provider to not be silent. This means that if a key requires a PIN to be used then Windows will open a prompt requesting the key. This is needed to use keys protected by HSM devices like Yubikey which requires the pin prompt.

The parameter -Silent has been added to the
Add/Set-OpenAuthenticodeSignature cmdlets to bring back the original behaviour if it is desired.