### PR TITLE
Fix up support for ECDSA certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for OpenAuthenticode
 
+## v0.4.0 - TBD
+
+* Fix support for ECDSA based key that was broken in `v0.3.0`
+
 ## v0.3.0 - 2023-08-24
 
 * Reworked Assembly Load Context to properly store extra dlls in new ALC

--- a/docs/en-US/Add-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Add-OpenAuthenticodeSignature.md
@@ -53,6 +53,7 @@ It is possible to sign a file using a certificate object with an associated key.
 The simplest way to get a certificate is to use the [Get-PfxCertificate cmdlet](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-pfxcertificate?view=powershell-7.3) which works on both Windows and non-Windows hosts.
 It is also possible to get a code signing certificate through the `Cert:\` provider alongside the `-CodeSigningCert` parameter on Windows.
 The certificate must have the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)` for it to be used with Authenticode.
+The certificate must also use the RSA or ECDSA key algorithm for it to be used, other algorithms are not implemented.
 While it should be signed by a trusted CA authority for it to be validated normally, it is not a requirement to sign the file.
 
 See [about_AuthenticodeProviders](./about_AuthenticodeProviders.md) for more information about what providers are currently supported.
@@ -88,8 +89,13 @@ Like example 1 but also adds a counter signature with the Digicert timestamp ser
 ### -Certificate
 The certificate used to sign the files specified.
 Use the `Get-PfxCertificate` or `Get-ChildItem Cert:\... -CodeSigningCert` (Windows only) to get a certificate to use for signing.
-The certificate must have access to its associated private key for it to be able to sign the file.
-It should also have the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)`.
+A valid certificate must meet the following requirements:
+
++ Must have access to its associated private key for it to be able to sign the file.
+
++ Has the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)`.
+
++ Uses the RSA or ECDSA signature algorithm
 
 ```yaml
 Type: X509Certificate2

--- a/docs/en-US/Set-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Set-OpenAuthenticodeSignature.md
@@ -54,6 +54,7 @@ It is possible to sign a file using a certificate object with an associated key.
 The simplest way to get a certificate is to use the [Get-PfxCertificate cmdlet](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-pfxcertificate?view=powershell-7.3) which works on both Windows and non-Windows hosts.
 It is also possible to get a code signing certificate through the `Cert:\` provider alongside the `-CodeSigningCert` parameter on Windows.
 The certificate must have the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)` for it to be used with Authenticode.
+The certificate must also use the RSA or ECDSA key algorithm for it to be used, other algorithms are not implemented.
 While it should be signed by a trusted CA authority for it to be validated normally, it is not a requirement to sign the file.
 
 See [about_AuthenticodeProviders](./about_AuthenticodeProviders.md) for more information about what providers are currently supported.
@@ -95,8 +96,13 @@ This does not include any pre-requisite steps for setting up the authentication 
 ### -Certificate
 The certificate used to sign the files specified.
 Use the `Get-PfxCertificate` or `Get-ChildItem Cert:\... -CodeSigningCert` (Windows only) to get a certificate to use for signing.
-The certificate must have access to its associated private key for it to be able to sign the file.
-It should also have the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)`.
+A valid certificate must meet the following requirements:
+
++ Must have access to its associated private key for it to be able to sign the file.
+
++ Has the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)`.
+
++ Uses the RSA or ECDSA signature algorithm
 
 ```yaml
 Type: X509Certificate2

--- a/docs/en-US/about_AuthenticodeProviders.md
+++ b/docs/en-US/about_AuthenticodeProviders.md
@@ -14,10 +14,10 @@ Currently the following providers have been implemented in this module.
 |PowerShellXml|`.psc1`, `.ps1xml`|Yes|
 |PEBinary|`.dll`, `.exe`|No|
 
-The `Get-OpenAuthenticodeSignature` and `Set-OpenAuthenticodeSignature` uses the extension on the file path provided to determine what provider to use.
+The `Get-OpenAuthenticodeSignature`, `Set-OpenAuthenticodeSignature`, and `Add-OpenAuthenticodeSignature` uses the extension on the file path provided to determine what provider to use.
 If the file has no provider, or one of the content parameters are used, an explicit provider can be specified with `-Provider`.
 An explicit provider can also be specified to override the extension lookup if that is desired for any reason.
-If a provider supports string contents, the `-Content` parameter can be used with `Get-AuthenticodeSignature` to get a signature from a string value.
+If a provider supports string contents, the `-Content` parameter can be used with `Get-OpenAuthenticodeSignature` to get a signature from a string value.
 
 Each provider provides a way to:
 

--- a/module/OpenAuthenticode.psd1
+++ b/module/OpenAuthenticode.psd1
@@ -14,7 +14,7 @@
     RootModule = 'OpenAuthenticode.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.3.0'
+    ModuleVersion = '0.4.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/OpenAuthenticode/SignatureHelper.cs
+++ b/src/OpenAuthenticode/SignatureHelper.cs
@@ -249,9 +249,9 @@ public record CounterSignature(X509Certificate2 Certificate, HashAlgorithmName H
     DateTime TimeStamp);
 
 
-internal sealed class CaptureHashKey : RSA
+internal sealed class RSACaptureHashKey : RSA
 {
-    public CaptureHashKey() { }
+    public RSACaptureHashKey() { }
 
     public override RSAParameters ExportParameters(bool includePrivateParameters)
         => throw new NotImplementedException();
@@ -262,6 +262,21 @@ internal sealed class CaptureHashKey : RSA
     public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
     {
         throw new CapturedHashException(hash);
+    }
+}
+
+internal sealed class ECDsaCaptureHashKey : ECDsa
+{
+    public ECDsaCaptureHashKey() { }
+
+    public override byte[] SignHash(byte[] hash)
+    {
+        throw new CapturedHashException(hash);
+    }
+
+    public override bool VerifyHash(byte[] hash, byte[] signature)
+    {
+        throw new NotImplementedException();
     }
 }
 


### PR DESCRIPTION
The previous release broke compatibility with ECDSA certificates due to how it pre-calculated the hashes with a fixed RSA key. This PR changes the code to derive the capturing key based on the certificates public key algorithm. It also adds some tests to ensure this doesn't happen again.