### PR TITLE
Add support for Azure ECDSA keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0 - TBD
 
 * Fix support for ECDSA based key that was broken in `v0.3.0`
+* Add support for ECDSA keys from Azure using `Get-OpenAuthenticodeAzKey`
 
 ## v0.3.0 - 2023-08-24
 

--- a/docs/en-US/Add-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Add-OpenAuthenticodeSignature.md
@@ -142,7 +142,8 @@ Accept wildcard characters: False
 
 ### -HashAlgorithm
 The hashing algorithm to use when generating the Authenticode signature.
-This defaults to SHA256 if not specified.
+If a `-Key` was specified and had a set default hash algorithm, that algorithm will be used as the default.
+If no `-Key` was specified, or the key had no default hash algorithm, `SHA256` will be used.
 
 Known algorithms are:
 

--- a/docs/en-US/Get-OpenAuthenticodeAzKey.md
+++ b/docs/en-US/Get-OpenAuthenticodeAzKey.md
@@ -32,6 +32,7 @@ The certificate must also have the Key Usage of `Digital Signature (80)` and Enh
 
 Currently authentication relies on the lookup behaviour of [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet).
 It will lookup environment variables, device managed identities, az cli contexts, etc to authenticate with Azure.
+If the [Az.Accounts](https://www.powershellgallery.com/packages/Az.Accounts/) PowerShell module has been installed, the [Connect-AzAccount](https://learn.microsoft.com/en-us/powershell/module/az.accounts/connect-azaccount?view=azps-10.2.0) cmdlet can be used to authenticate the session before this cmdlet is called.
 It has not been set to allow for interactive authentication through the web browser.
 
 See [about_AuthenticodeAzureKeys](./about_AuthenticodeAzureKeys.md) for more information on how a key can be used to sign files.
@@ -93,6 +94,9 @@ None
 The AzureKey object that can be used with the `-Key` parameter in `Set-OpenAuthenticodeSignature`.
 
 ## NOTES
+Both RSA and ECDSA keys are supported with this cmdlet.
+When using an ECDSA key with `Set-OpenAuthenticodeSignature`, the `-HashAlgorithm` parameter used needs to match the ECDSA key digest size.
+Omit the `-HashAlgorithm` parameter for the cmdlet to use the correct hash algorithm.
 
 ## RELATED LINKS
 

--- a/docs/en-US/Set-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Set-OpenAuthenticodeSignature.md
@@ -149,7 +149,8 @@ Accept wildcard characters: False
 
 ### -HashAlgorithm
 The hashing algorithm to use when generating the Authenticode signature.
-This defaults to SHA256 if not specified.
+If a `-Key` was specified and had a set default hash algorithm, that algorithm will be used as the default.
+If no `-Key` was specified, or the key had no default hash algorithm, `SHA256` will be used.
 
 Known algorithms are:
 

--- a/docs/en-US/about_AuthenticodeAzureKeys.md
+++ b/docs/en-US/about_AuthenticodeAzureKeys.md
@@ -114,5 +114,30 @@ $signParams = @{
 Set-OpenAuthenticodeSignature -FilePath $path @signParams
 ```
 
+If the [Az.Accounts](https://www.powershellgallery.com/packages/Az.Accounts/) module is installed it can be used to authenticate with Azure using the parameters it exposed.
+Once authenticated the `Get-OpenAuthenticodeAzKey` will reuse that authenticated context when retrieving the key.
+
+```powershell
+$credInfo = ConvertFrom-Json -InputObject $env:AZURE_CREDENTIALS
+$vaultName = $credInfo.vaultName
+$vaultCert = $credInfo.vaultCert
+$cred = ... # Left up to the reader to build
+
+$connectParams = @{
+    TenantId = $credInfo.tenantId
+    ServicePrincipal = $true
+    Credential = $cred
+}
+Connect-AzAccount @connectParams
+
+$key = Get-OpenAuthenticodeAzKey -Vault $vaultName -Certificate $vaultCert
+$signParams = @{
+    Key = $key
+    TimeStampServer = 'http://timestamp.digicert.com'
+    HashAlgorithm = 'SHA256'
+}
+Set-OpenAuthenticodeSignature -FilePath $path @signParams
+```
+
 In this example the output json from the bash script has been stored in the environment variable `AZURE_CREDENTIALS`.
 Ensure the credentials json is stored securely so that it cannot be used for any unauthorised signing operations.

--- a/src/OpenAuthenticode.Module/AzureKeyVault.cs
+++ b/src/OpenAuthenticode.Module/AzureKeyVault.cs
@@ -1,58 +1,79 @@
 using System;
-using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Azure.Identity;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys.Cryptography;
+using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
 
 namespace OpenAuthenticode.Shared;
 
 public sealed class AzureKey : KeyProvider, IDisposable
 {
     private readonly CryptographyClient _client;
-    private readonly string _keyAlgorithm;
-    private readonly Dictionary<string, SignatureAlgorithm> _algorithmMap;
-    private readonly static byte[] _rsaSha1Digest = new byte[] {
-        0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E,
-        0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14,
-    };
 
     public override X509Certificate2 Certificate { get; }
 
     internal override AsymmetricAlgorithm Key { get; }
 
-    private AzureKey(CryptographyClient client, X509Certificate2 cert)
+    internal override HashAlgorithmName? DefaultHashAlgorithm { get; }
+
+    private AzureKey(CryptographyClient client, X509Certificate2 cert, string? curveName)
     {
         _client = client;
-        _keyAlgorithm = cert.GetKeyAlgorithm();
-
         Certificate = cert;
-        if (_keyAlgorithm == "1.2.840.113549.1.1.1") // RSA
+
+        using RSA? rsaPubKey = cert.GetRSAPublicKey();
+        if (rsaPubKey != null)
         {
-            _algorithmMap = new()
+            Key = new AzureKeyVaultRSAKey(_client);
+            return;
+        }
+
+        using ECDsa? ecdsaPubKey = cert.GetECDsaPublicKey();
+        if (ecdsaPubKey != null)
+        {
+            int digestSize;
+            AzureSignatureAlgorithm sigAlgo;
+            if (curveName == CertificateKeyCurveName.P256)
             {
-                {HashAlgorithmName.SHA1.Name!, new SignatureAlgorithm("RSNULL")},
-                {HashAlgorithmName.SHA256.Name!, SignatureAlgorithm.RS256},
-                {HashAlgorithmName.SHA384.Name!, SignatureAlgorithm.RS384},
-                {HashAlgorithmName.SHA512.Name!, SignatureAlgorithm.RS512},
-            };
-            Key = new AzureKeyVaultRSAKey(this);
+                DefaultHashAlgorithm = HashAlgorithmName.SHA256;
+                sigAlgo = AzureSignatureAlgorithm.ES256;
+                digestSize = 32;
+            }
+            else if (curveName == CertificateKeyCurveName.P256K)
+            {
+                DefaultHashAlgorithm = HashAlgorithmName.SHA256;
+                sigAlgo = AzureSignatureAlgorithm.ES256K;
+                digestSize = 32;
+            }
+            else if (curveName == CertificateKeyCurveName.P384)
+            {
+                DefaultHashAlgorithm = HashAlgorithmName.SHA384;
+                sigAlgo = AzureSignatureAlgorithm.ES384;
+                digestSize = 48;
+            }
+            else if (curveName == CertificateKeyCurveName.P521)
+            {
+                DefaultHashAlgorithm = HashAlgorithmName.SHA512;
+                sigAlgo = AzureSignatureAlgorithm.ES512;
+                digestSize = 64;
+            }
+            else
+            {
+                throw new NotImplementedException($"Unsupported ECDSA Key vault key with curve {curveName}");
+            }
+
+            Key = new AzureKeyVaultECDSAKey(_client, sigAlgo, digestSize, DefaultHashAlgorithm.ToString()!);
+            return;
         }
-        // else if (_keyAlgorithm == "1.2.840.10045.2.1") // ECC
-        // {
-        //     _algorithmMap = new()
-        //     {
-        //         {HashAlgorithmName.SHA256.Name!, SignatureAlgorithm.ES256},
-        //         {HashAlgorithmName.SHA384.Name!, SignatureAlgorithm.ES384},
-        //         {HashAlgorithmName.SHA512.Name!, SignatureAlgorithm.ES512},
-        //     };
-        //     Key = new AzureKeyVaultECDSAKey(this);
-        // }
-        else
+
+        string keyAlgorithm = cert.PublicKey.Oid.Value ?? "";
+        if (!string.IsNullOrWhiteSpace(cert.PublicKey.Oid.FriendlyName))
         {
-            throw new NotImplementedException($"Azure Key vault does not support the key algorithm {_keyAlgorithm}");
+            keyAlgorithm += $" - {cert.PublicKey.Oid.FriendlyName}";
         }
+        throw new NotImplementedException($"Azure Key vault does not support the key algorithm {keyAlgorithm}");
     }
 
     internal static AzureKey Create(string vaultName, string keyName)
@@ -65,32 +86,9 @@ public sealed class AzureKey : KeyProvider, IDisposable
         KeyVaultCertificateWithPolicy certInfo = certClient.GetCertificate(keyName);
         X509Certificate2 cert = new(certInfo.Cer);
 
-        Uri keyId = new($"{keyVaultUrl}keys/{keyName}/");
-        CryptographyClient c = new(keyId, cred);
-        return new AzureKey(c, cert);
-    }
-
-    internal byte[] Sign(byte[] hash, HashAlgorithmName hashAlgorithm)
-    {
-        if (!_algorithmMap.TryGetValue(hashAlgorithm.Name!, out var signatureAlgorithm))
-        {
-            throw new NotImplementedException($"Unknown algorithm {hashAlgorithm.Name} for {_keyAlgorithm}");
-        }
-        if (signatureAlgorithm == "RSNULL")
-        {
-            hash = CreateRSASha1Digest(hash);
-        }
-
-        return _client.Sign(signatureAlgorithm, hash).Signature;
-    }
-
-    private static byte[] CreateRSASha1Digest(byte[] hash)
-    {
-        byte[] pkcs1Digest = new byte[_rsaSha1Digest.Length + 20];
-        _rsaSha1Digest.CopyTo(pkcs1Digest, 0);
-        hash.CopyTo(pkcs1Digest, _rsaSha1Digest.Length);
-
-        return pkcs1Digest;
+        string? curveName = certInfo.Policy.KeyCurveName?.ToString();
+        CryptographyClient c = new(certInfo.KeyId, cred);
+        return new AzureKey(c, cert, curveName);
     }
 
     public void Dispose()
@@ -103,10 +101,16 @@ public sealed class AzureKey : KeyProvider, IDisposable
 
 internal sealed class AzureKeyVaultRSAKey : RSA
 {
-    private readonly AzureKey _key;
-    public AzureKeyVaultRSAKey(AzureKey key)
+    private readonly CryptographyClient _client;
+
+    private readonly static byte[] _rsaSha1Digest = new byte[] {
+        0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E,
+        0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14,
+    };
+
+    public AzureKeyVaultRSAKey(CryptographyClient client)
     {
-        _key = key;
+        _client = client;
     }
 
     public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
@@ -116,10 +120,81 @@ internal sealed class AzureKeyVaultRSAKey : RSA
             throw new CryptographicException($"Unsupported padding mode {padding.Mode}");
         }
 
-        return _key.Sign(hash, hashAlgorithm);
+        AzureSignatureAlgorithm sigAlgo;
+        if (hashAlgorithm == HashAlgorithmName.SHA1)
+        {
+            hash = CreateRSASha1Digest(hash);
+            sigAlgo = new AzureSignatureAlgorithm("RSNULL");
+        }
+        else if (hashAlgorithm == HashAlgorithmName.SHA256)
+        {
+            sigAlgo = AzureSignatureAlgorithm.RS256;
+        }
+        else if (hashAlgorithm == HashAlgorithmName.SHA384)
+        {
+            sigAlgo = AzureSignatureAlgorithm.RS384;
+        }
+        else if (hashAlgorithm == HashAlgorithmName.SHA512)
+        {
+            sigAlgo = AzureSignatureAlgorithm.RS512;
+        }
+        else
+        {
+            string msg = "Support for the hash algorithm requested '{0}' for this RSA key has not been implemented";
+            throw new CryptographicException(string.Format(msg, hashAlgorithm.Name));
+        }
+
+        return _client.Sign(sigAlgo, hash).Signature;
     }
 
     public override RSAParameters ExportParameters(bool includePrivateParameters) => throw new NotImplementedException();
 
     public override void ImportParameters(RSAParameters parameters) => throw new NotImplementedException();
+
+    private static byte[] CreateRSASha1Digest(byte[] hash)
+    {
+        byte[] pkcs1Digest = new byte[_rsaSha1Digest.Length + 20];
+        _rsaSha1Digest.CopyTo(pkcs1Digest, 0);
+        hash.CopyTo(pkcs1Digest, _rsaSha1Digest.Length);
+
+        return pkcs1Digest;
+    }
+}
+
+internal sealed class AzureKeyVaultECDSAKey : ECDsa
+{
+    private readonly CryptographyClient _client;
+    private readonly AzureSignatureAlgorithm _sigAlgo;
+    private readonly int _digestSize;
+    private readonly string _neededAlgorithm;
+
+    public AzureKeyVaultECDSAKey(
+        CryptographyClient client,
+        AzureSignatureAlgorithm signatureAlgorithm,
+        int digestSize,
+        string neededAlgorithm
+    )
+    {
+        _client = client;
+        _digestSize = digestSize;
+        _neededAlgorithm = neededAlgorithm;
+        _sigAlgo = signatureAlgorithm;
+    }
+
+    public override byte[] SignHash(byte[] hash)
+    {
+        if (hash.Length != _digestSize)
+        {
+            string msg = "The digest size {0} is not valid for digest algorithm of this ECDSA key '{1}'. " +
+            "Ensure -HashAlgorithm {1} was specified or omit the parameter to use the defaults.";
+            throw new CryptographicException(string.Format(msg, hash.Length, _neededAlgorithm));
+        }
+
+        return _client.Sign(_sigAlgo, hash).Signature;
+    }
+
+    public override bool VerifyHash(byte[] hash, byte[] signature)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/OpenAuthenticode/KeyProvider.cs
+++ b/src/OpenAuthenticode/KeyProvider.cs
@@ -21,6 +21,11 @@ public abstract class KeyProvider
     /// </summary>
     internal abstract AsymmetricAlgorithm Key { get; }
 
+    /// <summary>
+    /// The hash algorithm to use for this key if none was specified.
+    /// </summary>
+    internal virtual HashAlgorithmName? DefaultHashAlgorithm { get; } = null;
+
     internal virtual void RegisterHashToSign(Span<byte> hash, Span<byte> content, HashAlgorithmName hashAlgorithm)
     { }
 

--- a/tests/Get-OpenAuthenticodeAzKey.Tests.ps1
+++ b/tests/Get-OpenAuthenticodeAzKey.Tests.ps1
@@ -7,15 +7,20 @@ Function Test-Available {
 
     if (
         $env:AZURE_TENANT_ID -and
-        $env:AZURE_CLIENT_ID -and
         (
-            $env:AZURE_CLIENT_SECRET -or
-            $env:AZURE_CLIENT_CERTIFICATE_PATH
+            (
+                $env:AZURE_CONNECT_APPLICATION -and
+                (Get-Command -Name Connect-AzAccount -ErrorAction SilentlyContinue)
+            ) -or
+            (
+                $env:AZURE_CLIENT_ID -and
+                (
+                    $env:AZURE_CLIENT_SECRET -or
+                    $env:AZURE_CLIENT_CERTIFICATE_PATH
+                )
+            )
         ) -and
-        $env:AZURE_KEYVAULT_NAME -and
-        (
-            $env:AZURE_KEYVAULT_RSA_CERTIFICATE
-        )
+        $env:AZURE_KEYVAULT_NAME
     ) {
         $true
     }
@@ -26,21 +31,46 @@ Function Test-Available {
 
 Describe "Get-OpenAuthenticodeAzKey" -Skip:(-not (Test-Available)) {
     BeforeAll {
+        if ($env:AZURE_CONNECT_APPLICATION -and (Get-Command -Name Connect-AzAccount -ErrorAction SilentlyContinue)) {
+            Connect-AzAccount -TenantId $env:AZURE_TENANT_ID
+        }
+
         $rsaKey = if ($env:AZURE_KEYVAULT_RSA_CERTIFICATE) {
             Get-OpenAuthenticodeAzKey -Vault $env:AZURE_KEYVAULT_NAME -Certificate $env:AZURE_KEYVAULT_RSA_CERTIFICATE
         }
-
+        $ecdsaP256Key = if ($env:AZURE_KEYVAULT_ECDSA_P256_CERTIFICATE) {
+            Get-OpenAuthenticodeAzKey -Vault $env:AZURE_KEYVAULT_NAME -Certificate $env:AZURE_KEYVAULT_ECDSA_P256_CERTIFICATE
+        }
+        $ecdsaP256KKey = if ($env:AZURE_KEYVAULT_ECDSA_P256K_CERTIFICATE) {
+            Get-OpenAuthenticodeAzKey -Vault $env:AZURE_KEYVAULT_NAME -Certificate $env:AZURE_KEYVAULT_ECDSA_P256K_CERTIFICATE
+        }
+        $ecdsaP384Key = if ($env:AZURE_KEYVAULT_ECDSA_P384_CERTIFICATE) {
+            Get-OpenAuthenticodeAzKey -Vault $env:AZURE_KEYVAULT_NAME -Certificate $env:AZURE_KEYVAULT_ECDSA_P384_CERTIFICATE
+        }
+        $ecdsaP521Key = if ($env:AZURE_KEYVAULT_ECDSA_P521_CERTIFICATE) {
+            Get-OpenAuthenticodeAzKey -Vault $env:AZURE_KEYVAULT_NAME -Certificate $env:AZURE_KEYVAULT_ECDSA_P521_CERTIFICATE
+        }
+        $ecdsaKeys = @{
+            P256 = $ecdsaP256Key
+            P256K = $ecdsaP256KKey
+            P384 = $ecdsaP384Key
+            P521 = $ecdsaP521Key
+        }
     }
     AfterAll {
         if ($rsaKey) { $rsaKey.Dispose() }
+        if ($ecdsaP256Key) { $ecdsaP256Key.Dispose() }
+        if ($ecdsaP256KKey) { $ecdsaP256KKey.Dispose() }
+        if ($ecdsaP384Key) { $ecdsaP384Key.Dispose() }
+        if ($ecdsaP521Key) { $ecdsaP521Key.Dispose() }
     }
 
     It "Signs with RSA key and hash <Name>" -TestCases @(
-        @{Name = "Default" }
-        @{Name = "SHA1" }
-        @{Name = "SHA256" }
-        @{Name = "SHA384" }
-        @{Name = "SHA512" }
+        @{ Name = "Default" }
+        @{ Name = "SHA1" }
+        @{ Name = "SHA256" }
+        @{ Name = "SHA384" }
+        @{ Name = "SHA512" }
     ) {
         param ($Name)
 
@@ -63,11 +93,64 @@ Describe "Get-OpenAuthenticodeAzKey" -Skip:(-not (Test-Available)) {
 
         $actual = Get-OpenAuthenticodeSignature -Path $scriptPath -SkipCertificateCheck
         $actual.HashAlgorithm | Should -Be $Name
-        $actual.Certificate.GetKeyAlgorithm() | Should -Be "1.2.840.113549.1.1.1"
+        $actual.Certificate.GetKeyAlgorithm() | Should -Be "1.2.840.113549.1.1.1"  # RSA
 
         If (Get-Command -Name Get-AuthenticodeSignature -ErrorAction Ignore) {
             $actual = Get-AuthenticodeSignature -FilePath $scriptPath.FullName
             $actual.Status | Should -Not -Be HashMismatch
         }
+    }
+
+    It "Signs with ECDSA <KeyAlgorithm> key" -TestCases @(
+        @{ KeyAlgorithm = "P256"; ExpectedAlgorithm = "SHA256" }
+        @{ KeyAlgorithm = "P256K"; ExpectedAlgorithm = "SHA256" }
+        @{ KeyAlgorithm = "P384"; ExpectedAlgorithm = "SHA384" }
+        @{ KeyAlgorithm = "P521"; ExpectedAlgorithm = "SHA512" }
+    ) {
+        param ($KeyAlgorithm, $ExpectedAlgorithm)
+
+        if (-not $ecdsaKeys[$KeyAlgorithm]) {
+            Set-ItResult -Skipped -Because "Env var AZURE_KEYVAULT_ECDSA_$($KeyAlgorithm)_CERTIFICATE is not set"
+        }
+
+        $scriptPath = New-Item -Path temp: -Name script.ps1 -Force -Value "Write-Host test`r`n"
+        $setParams = @{
+            Path = $scriptPath
+            Key = $ecdsaKeys[$KeyAlgorithm]
+        }
+        Set-OpenAuthenticodeSignature @setParams
+
+        $actual = Get-OpenAuthenticodeSignature -Path $scriptPath -SkipCertificateCheck
+        $actual.HashAlgorithm | Should -Be $ExpectedAlgorithm
+        $actual.Certificate.GetKeyAlgorithm() | Should -Be "1.2.840.10045.2.1"  # ECC
+
+        If (Get-Command -Name Get-AuthenticodeSignature -ErrorAction Ignore) {
+            $actual = Get-AuthenticodeSignature -FilePath $scriptPath.FullName
+            $actual.Status | Should -Not -Be HashMismatch
+        }
+    }
+
+    It "It attempts to sign ECDSA key with the wrong algorithm" {
+        $key = $null
+        foreach ($kvp in $ecdsaKeys.GetEnumerator()) {
+            if ($null -ne $kvp.Value) {
+                $key = $kvp.Value
+                break
+            }
+        }
+
+        if (-not $key) {
+            Set-ItResult -Skipped -Because "No ECDSA env vars AZURE_KEYVAULT_ECDSA_*_CERTIFICATE are set"
+        }
+
+        $scriptPath = New-Item -Path temp: -Name script.ps1 -Force -Value "Write-Host test`r`n"
+        $setParams = @{
+            Path = $scriptPath
+            Key = $key
+            HashAlgorithm = 'SHA1'
+        }
+        Set-OpenAuthenticodeSignature @setParams -ErrorAction SilentlyContinue -ErrorVariable err
+        $err.Count | Should -Be 1
+        [string]$err[0] | Should -BeLike "The digest size 20 is not valid for digest algorithm of this ECDSA key '*'. Ensure -HashAlgorithm * was specified or omit *"
     }
 }

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -51,17 +51,17 @@ Function global:New-X509Certificate {
             $key,
             $HashAlgorithm)
     }
-    elseif ($KeyAlgorithm.StartsWith('ECDH_', [System.StringComparison]::OrdinalIgnoreCase)) {
-        $curve = [System.Security.Cryptography.ECCurve+NamedCurves]::nistP256
-        # $curve = [System.Security.Cryptography.ECCurve]::CreateFromFriendlyName($KeyAlgorithm.Substring(5))
-        $key = [System.Security.Cryptography.ECDiffieHellman]::Create($curve)
-        # $copyFunc = { $args[0].CopyWithPrivateKey($key) }
-        $copyFunc = $null
-        $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
-            $Subject,
-            [System.Security.Cryptography.X509Certificates.PublicKey]::new($key),
-            $HashAlgorithm)
-    }
+    # I don't know too much about algorithms but ECDH and ECDSA seem to be the same
+    # I think ECDH is just the public key algorithm or something
+    # elseif ($KeyAlgorithm.StartsWith('ECDH_', [System.StringComparison]::OrdinalIgnoreCase)) {
+    #     $curve = [System.Security.Cryptography.ECCurve]::CreateFromFriendlyName($KeyAlgorithm.Substring(5))
+    #     $key = [System.Security.Cryptography.ECDiffieHellman]::Create($curve)
+    #     $copyFunc = { $args[0].CopyWithPrivateKey($key) }
+    #     $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+    #         $Subject,
+    #         [System.Security.Cryptography.X509Certificates.PublicKey]::new($key),
+    #         $HashAlgorithm)
+    # }
     else {
         throw "Unsupported KeyAlgorithm '$KeyAlgorithm'"
     }
@@ -98,13 +98,7 @@ Function global:New-X509Certificate {
         $cert = $request.Create($Issuer, $notBefore, $notAfter, $serialNumber)
 
         # For whatever reason Create does not create an X509 cert with the private key.
-        if ($copyFunc) {
-            &$copyFunc $cert
-        }
-        else {
-            $cert
-        }
-        # &$copyFunc $cert
+        &$copyFunc $cert
     }
     else {
         $notBefore = [DateTimeOffset]::UtcNow.AddDays(-1)


### PR DESCRIPTION
Adds support for using Azure Key Vault keys that use the ECDSA algorithm. When using an ECDSA key the -HashAlgorithm specified must match the key digest algorithm specified. For example an ECDSA_P256 key must be used with the HashAlgorithm SHA256. Omitting the HashAlgorithm will have the cmdlet use the correct algorithm by default.