### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for OpenAuthenticode
 
+## v0.5.0 - TBD
+
+* Bump the Azure and OTP dependencies to the latest version available
+
 ## v0.4.0 - 2023-08-25
 
 * Fix support for ECDSA based key that was broken in `v0.3.0`

--- a/src/OpenAuthenticode.Module/OpenAuthenticode.Module.csproj
+++ b/src/OpenAuthenticode.Module/OpenAuthenticode.Module.csproj
@@ -12,10 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
-    <PackageReference Include="Azure.Identity" Version="1.8.2" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.4.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.4.0" />
-    <PackageReference Include="Otp.NET" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.11.2" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
+    <PackageReference Include="Otp.NET" Version="1.4.0" />
     <ProjectReference Include="../OpenAuthenticode/OpenAuthenticode.csproj" />
   </ItemGroup>
 

--- a/src/OpenAuthenticode/OpenAuthenticode.csproj
+++ b/src/OpenAuthenticode/OpenAuthenticode.csproj
@@ -15,7 +15,12 @@
     <PackageReference Include="System.Formats.Asn1" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
     <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.0" PrivateAssets="all">
+      <!--
+        This cannot be raised until we raise our minimum PowerShell version.
+      -->
+      <NoWarn>NU1903</NoWarn>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/tools/InvokeBuild.ps1
+++ b/tools/InvokeBuild.ps1
@@ -69,7 +69,7 @@ task Sign {
         return
     }
 
-    Import-Module -Name (Join-Path $Manifest.PowerShellPath "$($Manifest.Module.Name).psd1") -ErrorAction Stop
+    Import-Module -Name (Join-Path $Manifest.ReleasePath "$($Manifest.Module.Name).psd1") -ErrorAction Stop
 
     Write-Host "Authenticating with Azure KeyVault '$vaultName' for signing" -ForegroundColor Cyan
     $key = Get-OpenAuthenticodeAzKey -Vault $vaultName -Certificate $vaultCert


### PR DESCRIPTION
Raises the versions of the various Azure and OTP dependencies used by the custom key providers. This fixes some CVE problems in the Azure deps and potentially include bugfixes that those new updates have.