### PR TITLE
Bump PowerShell version and fix encoding logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,18 +57,6 @@ jobs:
       fail-fast: false
       matrix:
         info:
-        - name: PS_7.2_x64_Windows
-          psversion: '7.2.0'
-          os: windows-latest
-        - name: PS_7.2_x64_Linux
-          psversion: '7.2.0'
-          os: ubuntu-latest
-        - name: PS_7.3_x64_Windows
-          psversion: '7.3.0'
-          os: windows-latest
-        - name: PS_7.3_x64_Linux
-          psversion: '7.3.0'
-          os: ubuntu-latest
         - name: PS_7.4_x64_Windows
           psversion: '7.4.0'
           os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v0.5.0 - TBD
 
+* Remove support for PowerShell 7.2 and 7.3 as they are end of life versions
 * Bump the Azure and OTP dependencies to the latest version available
+* Fix up PowerShell script encoding detection when no BOM is present
 
 ## v0.4.0 - 2023-08-25
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See [OpenAuthenticode index](docs/en-US/OpenAuthenticode.md) for more details.
 
 These cmdlets have the following requirements
 
-* PowerShell v7.2 or newer
+* PowerShell v7.4 or newer
 
 ## Examples
 

--- a/module/OpenAuthenticode.psm1
+++ b/module/OpenAuthenticode.psm1
@@ -13,7 +13,7 @@ $isReload = $true
 if (-not ('OpenAuthenticode.LoadContext' -as [type])) {
     $isReload = $false
 
-    Add-Type -Path ([System.IO.Path]::Combine($PSScriptRoot, 'bin', 'net6.0', "$moduleName.dll"))
+    Add-Type -Path ([System.IO.Path]::Combine($PSScriptRoot, 'bin', 'net8.0', "$moduleName.dll"))
 }
 
 $mainModule = [OpenAuthenticode.LoadContext]::Initialize()

--- a/src/OpenAuthenticode.Module/EncodingTransformationAttribute.cs
+++ b/src/OpenAuthenticode.Module/EncodingTransformationAttribute.cs
@@ -7,13 +7,21 @@ namespace OpenAuthenticode.Shared;
 
 public sealed class EncodingTransformAttribute : ArgumentTransformationAttribute
 {
-    public override object Transform(EngineIntrinsics engineIntrinsics, object inputData) => inputData switch
+    public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
     {
-        Encoding => inputData,
-        string s => GetEncodingFromString(s.ToUpperInvariant()),
-        int i => Encoding.GetEncoding(i),
-        _ => throw new ArgumentTransformationMetadataException($"Could not convert input '{inputData}' to a valid Encoding object."),
-    };
+        if (inputData is PSObject psObj)
+        {
+            inputData = psObj.BaseObject;
+        }
+
+        return inputData switch
+        {
+            Encoding => inputData,
+            string s => GetEncodingFromString(s.ToUpperInvariant()),
+            int i => Encoding.GetEncoding(i),
+            _ => throw new ArgumentTransformationMetadataException($"Could not convert input '{inputData}' to a valid Encoding object."),
+        };
+    }
 
     private static Encoding GetEncodingFromString(string encoding) => encoding switch
     {

--- a/src/OpenAuthenticode.Module/OpenAuthenticode.Module.csproj
+++ b/src/OpenAuthenticode.Module/OpenAuthenticode.Module.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -11,12 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
-    <PackageReference Include="Azure.Identity" Version="1.11.2" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageReference Include="Otp.NET" Version="1.4.0" />
     <ProjectReference Include="../OpenAuthenticode/OpenAuthenticode.csproj" />
+
+    <!--
+    S.M.A brings in these deps but we don't rely on it directly. It's up to
+    the user to run with a newer PowerShell version that isn't affected.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-447r-wph3-92pm" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/src/OpenAuthenticode/OpenAuthenticode.csproj
+++ b/src/OpenAuthenticode/OpenAuthenticode.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,15 +12,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
-    <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.0" PrivateAssets="all">
-      <!--
-        This cannot be raised until we raise our minimum PowerShell version.
-      -->
-      <NoWarn>NU1903</NoWarn>
-    </PackageReference>
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
+    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" PrivateAssets="all" />
+
+    <!--
+    S.M.A brings in these deps but we don't rely on it directly. It's up to
+    the user to run with a newer PowerShell version that isn't affected.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-447r-wph3-92pm" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/tools/InvokeBuild.ps1
+++ b/tools/InvokeBuild.ps1
@@ -164,10 +164,6 @@ task PesterTests {
         return
     }
 
-    if (-not $Manifest.TestFramework) {
-        throw "No compatible target test framework for PowerShell '$($Manifest.PowerShellVersion)'"
-    }
-
     $dotnetTools = @(dotnet tool list --global) -join "`n"
     if (-not $dotnetTools.Contains('coverlet.console')) {
         Write-Host 'Installing dotnet tool coverlet.console' -ForegroundColor Yellow
@@ -207,7 +203,7 @@ task PesterTests {
             '--merge-with', $unitCoveragePath
         }
         if ($env:GITHUB_ACTIONS -eq 'true') {
-            Set-Content $sourceMappingFile "|$($Manifest.RepositoryPath)$([Path]::DirectorySeparatorChar)=/_/"
+            Set-Content -LiteralPath $sourceMappingFile "|$($Manifest.RepositoryPath)$([Path]::DirectorySeparatorChar)=/_/"
             '--source-mapping-file', $sourceMappingFile
         }
     )

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -136,7 +136,7 @@ class Manifest {
         foreach ($framework in $availableFrameworks) {
             foreach ($actualFramework in $this.TargetFrameworks) {
                 if ($actualFramework.StartsWith($framework)) {
-                    $this.TestFramework = $framework
+                    $this.TestFramework = $actualFramework
                     break
                 }
             }
@@ -180,6 +180,7 @@ Function Assert-PowerShell {
     $releaseArch = switch ($Arch) {
         X64 { 'x64' }
         X86 { 'x86' }
+        ARM64 { 'arm64' }
         default {
             $err = [ErrorRecord]::new(
                 [Exception]::new("Unsupported archecture requests '$_'"),


### PR DESCRIPTION
Bumps the minimum PowerShell version to 7.4 and fixes the logic to determine the encoding to use for PowerShell scripts without a BOM. This new logic matches the same that is used by the builtin PowerShell SIP implementation.