### PR TITLE
Added parameter to specify authentication method for Azure KeyVault key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for OpenAuthenticode
 
+## v0.6.0 - 2025-01-10
+
+* Added the `-TokenSource` parameter for `Get-OpenAuthenticodeAzKey` to specify the authentication method used.
+
 ## v0.5.0 - 2024-12-07
 
 * Remove support for PowerShell 7.2 and 7.3 as they are end of life versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for OpenAuthenticode
 
-## v0.6.0 - 2025-01-10
+## v0.6.0 - TBD
 
 * Added the `-TokenSource` parameter for `Get-OpenAuthenticodeAzKey` to specify the authentication method used.
 

--- a/docs/en-US/Get-OpenAuthenticodeAzKey.md
+++ b/docs/en-US/Get-OpenAuthenticodeAzKey.md
@@ -106,7 +106,7 @@ Parameter Sets: (All)
 Aliases: None
 
 Required: False
-Position: 2
+Position: Named
 Default value: Default
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Get-OpenAuthenticodeAzKey.md
+++ b/docs/en-US/Get-OpenAuthenticodeAzKey.md
@@ -13,7 +13,7 @@ Get an Azure KeyVault certificate and key for use with Authenticode signing.
 ## SYNTAX
 
 ```
-Get-OpenAuthenticodeAzKey [-Vault] <String> [-Certificate] <String> [<CommonParameters>]
+Get-OpenAuthenticodeAzKey [-Vault] <String> [-Certificate] <String> [-TokenSource] <AzureTokenSource> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,10 +30,11 @@ This ensures the key does not leave Azure itself but rather Azure is used to sig
 Currently only certificates signed with an RSA can be used, ECDSA support is planned for the future.
 The certificate must also have the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)` for it to be used with Authenticode.
 
-Currently authentication relies on the lookup behaviour of [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet).
+By default authentication relies on the lookup behaviour of [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet).
 It will lookup environment variables, device managed identities, az cli contexts, etc to authenticate with Azure.
 If the [Az.Accounts](https://www.powershellgallery.com/packages/Az.Accounts/) PowerShell module has been installed, the [Connect-AzAccount](https://learn.microsoft.com/en-us/powershell/module/az.accounts/connect-azaccount?view=azps-10.2.0) cmdlet can be used to authenticate the session before this cmdlet is called.
 It has not been set to allow for interactive authentication through the web browser.
+The `TokenSource` parameter can be used to specify different a different authentication method.
 
 See [about_AuthenticodeAzureKeys](./about_AuthenticodeAzureKeys.md) for more information on how a key can be used to sign files.
 
@@ -47,6 +48,15 @@ PS C:\> Set-AuthenticodeSignature test.ps1 -Key $key
 
 Gets the Azure KeyVault key `Authenticode` in the vault `code-signing-test` and uses it to sign the file `test.ps1`.
 This does not include any pre-requisite steps for setting up the authentication details used by `Get-OpenAuthenticodeAzKey`.
+
+### Example 2: Get key for use with signing using the authentication token from Azure PowerShell
+```powershell
+PS C:\> Connect-AzAccount
+PS C:\> $key = Get-OpenAuthenticodeAzKey -Vault code-signing-test -Certificate Authenticode -AuthenticationMethod AzurePowerShell
+PS C:\> Set-AuthenticodeSignature test.ps1 -Key $key
+```
+
+Authenticates with Azure PowerShell and then gets the Azure KeyVault key `Authenticode` in the vault `code-signing-test` and uses it to sign the file `test.ps1`.
 
 ## PARAMETERS
 
@@ -76,6 +86,28 @@ Aliases: VaultName
 Required: True
 Position: 0
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenSource
+The authentication method used.
+
+Supported sources include:
+* Default - [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet)
+* Environment - [EnvironmentCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet)
+* AzurePowerShell - [AzurePowerShellCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azurepowershellcredential?view=azure-dotnet)
+* AzureCli - [AzureCliCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential?view=azure-dotnet)
+* ManagedIdentity - [ManagedIdentityCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential?view=azure-dotnet)
+
+```yaml
+Type: AzureTokenSource
+Parameter Sets: (All)
+Aliases: None
+
+Required: False
+Position: 2
+Default value: Default
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Get-OpenAuthenticodeAzKey.md
+++ b/docs/en-US/Get-OpenAuthenticodeAzKey.md
@@ -34,7 +34,7 @@ By default authentication relies on the lookup behaviour of [DefaultAzureCredent
 It will lookup environment variables, device managed identities, az cli contexts, etc to authenticate with Azure.
 If the [Az.Accounts](https://www.powershellgallery.com/packages/Az.Accounts/) PowerShell module has been installed, the [Connect-AzAccount](https://learn.microsoft.com/en-us/powershell/module/az.accounts/connect-azaccount?view=azps-10.2.0) cmdlet can be used to authenticate the session before this cmdlet is called.
 It has not been set to allow for interactive authentication through the web browser.
-The `TokenSource` parameter can be used to specify different a different authentication method.
+The `-TokenSource` parameter can be used to specify different a different authentication method.
 
 See [about_AuthenticodeAzureKeys](./about_AuthenticodeAzureKeys.md) for more information on how a key can be used to sign files.
 

--- a/docs/en-US/about_AuthenticodeAzureKeys.md
+++ b/docs/en-US/about_AuthenticodeAzureKeys.md
@@ -234,3 +234,11 @@ $signParams = @{
 }
 Set-OpenAuthenticodeSignature -FilePath $path @signParams
 ```
+
+Because DefaultAzureCredential authenticates in a [pre-defined order](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) `Get-OpenAuthenticodeAzKey` may not use the expected authentication method if others are available. For example if a managed identity is configured on the compute resource, it will take priority over Az CLI and Azure PowerShell.
+
+This behaviour can be overwritten with the `TokenSource` parameter of [Get-OpenAuthenticodeAzKey](./Get-OpenAuthenticodeAzKey.md).
+
+```powershell
+$key = Get-OpenAuthenticodeAzKey -Vault $vaultName -Certificate $vaultCert -TokenSource AzurePowerShell
+```

--- a/docs/en-US/about_AuthenticodeAzureKeys.md
+++ b/docs/en-US/about_AuthenticodeAzureKeys.md
@@ -237,7 +237,7 @@ Set-OpenAuthenticodeSignature -FilePath $path @signParams
 
 Because DefaultAzureCredential authenticates in a [pre-defined order](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) `Get-OpenAuthenticodeAzKey` may not use the expected authentication method if others are available. For example if a managed identity is configured on the compute resource, it will take priority over Az CLI and Azure PowerShell.
 
-This behaviour can be overwritten with the `TokenSource` parameter of [Get-OpenAuthenticodeAzKey](./Get-OpenAuthenticodeAzKey.md).
+This behaviour can be overwritten with the `-TokenSource` parameter of [Get-OpenAuthenticodeAzKey](./Get-OpenAuthenticodeAzKey.md).
 
 ```powershell
 $key = Get-OpenAuthenticodeAzKey -Vault $vaultName -Certificate $vaultCert -TokenSource AzurePowerShell

--- a/module/OpenAuthenticode.psd1
+++ b/module/OpenAuthenticode.psd1
@@ -14,7 +14,7 @@
     RootModule = 'OpenAuthenticode.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.5.0'
+    ModuleVersion = '0.6.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/OpenAuthenticode.Module/AzureKeyVault.cs
+++ b/src/OpenAuthenticode.Module/AzureKeyVault.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using Azure.Identity;
+using Azure.Core;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
@@ -76,11 +76,11 @@ public sealed class AzureKey : KeyProvider, IDisposable
         throw new NotImplementedException($"Azure Key vault does not support the key algorithm {keyAlgorithm}");
     }
 
-    internal static AzureKey Create(string vaultName, string keyName)
+    internal static AzureKey Create(string vaultName, string keyName, AzureTokenSource tokenSource)
     {
         string keyVaultUrl = $"https://{vaultName}.vault.azure.net/";
 
-        DefaultAzureCredential cred = new(includeInteractiveCredentials: false);
+        TokenCredential cred = TokenCredentialBuilder.GetTokenCredential(tokenSource);
 
         CertificateClient certClient = new(new Uri(keyVaultUrl), cred);
         KeyVaultCertificateWithPolicy certInfo = certClient.GetCertificate(keyName);

--- a/src/OpenAuthenticode.Module/AzureTokenSource.cs
+++ b/src/OpenAuthenticode.Module/AzureTokenSource.cs
@@ -1,0 +1,29 @@
+using Azure.Core;
+using Azure.Identity;
+
+namespace OpenAuthenticode.Shared {
+    public enum AzureTokenSource {
+        Default,
+        Environment,
+        AzurePowerShell,
+        AzureCli,
+        ManagedIdentity,
+    }
+
+    public class TokenCredentialBuilder {
+        public static TokenCredential GetTokenCredential(AzureTokenSource tokenSource) {
+            switch(tokenSource) {
+                case AzureTokenSource.Environment:
+                    return new EnvironmentCredential();
+                case AzureTokenSource.AzurePowerShell:
+                    return new AzurePowerShellCredential();
+                case AzureTokenSource.AzureCli:
+                    return new AzureCliCredential();
+                case AzureTokenSource.ManagedIdentity:
+                    return new ManagedIdentityCredential();
+                default:
+                    return new DefaultAzureCredential(includeInteractiveCredentials: false);
+            }
+        }
+    }
+}

--- a/src/OpenAuthenticode.Module/OpenAuthenticodeAzKey.cs
+++ b/src/OpenAuthenticode.Module/OpenAuthenticodeAzKey.cs
@@ -15,7 +15,7 @@ public sealed class GetOpenAuthenticodeAzKey : PSCmdlet
     [Alias("CertificateName")]
     public string Certificate { get; set; } = "";
 
-    [Parameter(Position = 2)]
+    [Parameter()]
     public AzureTokenSource TokenSource { get; set; } = AzureTokenSource.Default;
 
     protected override void ProcessRecord()

--- a/src/OpenAuthenticode.Module/OpenAuthenticodeAzKey.cs
+++ b/src/OpenAuthenticode.Module/OpenAuthenticodeAzKey.cs
@@ -15,11 +15,14 @@ public sealed class GetOpenAuthenticodeAzKey : PSCmdlet
     [Alias("CertificateName")]
     public string Certificate { get; set; } = "";
 
+    [Parameter(Position = 2)]
+    public AzureTokenSource TokenSource { get; set; } = AzureTokenSource.Default;
+
     protected override void ProcessRecord()
     {
         try
         {
-            WriteObject(AzureKey.Create(Vault, Certificate));
+            WriteObject(AzureKey.Create(Vault, Certificate, TokenSource));
         }
         catch (Exception e)
         {


### PR DESCRIPTION
As per #21 this pull request is to allow specifying the authentication method of `Get-OpenAuthenticodeAzKey` using a new parameter `-TokenSource`

I also added/updated the documentation and added some limited tests that will make sure a TokenCredential can be constructed for each AzureTokenSource value.