### PR TITLE
Add support for Azure Trusted Signing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "type": "shell",
             "args": [
                 "-Command",
-                "Import-Module ${workspaceFolder}/output/OpenAuthenticode; Import-Module ${workspaceFolder}/tools/Modules/platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
+                "Import-Module ${workspaceFolder}/output/OpenAuthenticode; Import-Module ${workspaceFolder}/output/Modules/platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
             ],
             "problemMatcher": [],
             "dependsOn": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.6.0 - TBD
 
 * Added the `-TokenSource` parameter for `Get-OpenAuthenticodeAzKey` to specify the authentication method used.
+* Added the following cmdlets
+  * [Get-OpenAuthenticodeAzTrustedSigner](./docs/en-US/Get-OpenAuthenticodeAzTrustedSigner.md) - uses Azure Trusted Signer to sign the provided files
 
 ## v0.5.0 - 2024-12-07
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ More format are planned for the future.
 
 See [OpenAuthenticode index](docs/en-US/OpenAuthenticode.md) for more details.
 
+> [!NOTE]
+> While this can do a standard certificate CA check, it does not currently implement any revocation checks so may not be viable for using as your own trust source.
+
 ## Requirements
 
 These cmdlets have the following requirements

--- a/docs/en-US/Add-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Add-OpenAuthenticodeSignature.md
@@ -17,7 +17,8 @@ Adds an authenticode signature to a file.
 Add-OpenAuthenticodeSignature [-Path] <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PathKey
@@ -25,7 +26,8 @@ Add-OpenAuthenticodeSignature [-Path] <String[]> -Certificate <X509Certificate2>
 Add-OpenAuthenticodeSignature [-Path] <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### LiteralPathCertificate
@@ -33,7 +35,8 @@ Add-OpenAuthenticodeSignature [-Path] <String[]> -Key <KeyProvider> [-Encoding <
 Add-OpenAuthenticodeSignature -LiteralPath <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### LiteralPathKey
@@ -41,7 +44,8 @@ Add-OpenAuthenticodeSignature -LiteralPath <String[]> -Certificate <X509Certific
 Add-OpenAuthenticodeSignature -LiteralPath <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -255,6 +259,21 @@ Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
+```
+
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Provider

--- a/docs/en-US/Clear-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Clear-OpenAuthenticodeSignature.md
@@ -15,13 +15,14 @@ Removes all Authenticode signatures from the path specified.
 ### Path (Default)
 ```
 Clear-OpenAuthenticodeSignature [-Path] <String[]> [-Encoding <Encoding>] [-Provider <AuthenticodeProvider>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPath
 ```
 Clear-OpenAuthenticodeSignature -LiteralPath <String[]> [-Encoding <Encoding>]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -114,6 +115,21 @@ Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
+```
+
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Provider

--- a/docs/en-US/Get-OpenAuthenticodeAzKey.md
+++ b/docs/en-US/Get-OpenAuthenticodeAzKey.md
@@ -13,7 +13,8 @@ Get an Azure KeyVault certificate and key for use with Authenticode signing.
 ## SYNTAX
 
 ```
-Get-OpenAuthenticodeAzKey [-Vault] <String> [-Certificate] <String> [-TokenSource] <AzureTokenSource> [<CommonParameters>]
+Get-OpenAuthenticodeAzKey [-Vault] <String> [-Certificate] <String> [-TokenSource <AzureTokenSource>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,7 +28,6 @@ The authenticated Azure principal must have the following Azure access policy pe
 The signing workflow does not require the key to be present on the local machine as it calls the Azure `Sign` API with the Authenticode digest.
 This ensures the key does not leave Azure itself but rather Azure is used to sign the data remotely.
 
-Currently only certificates signed with an RSA can be used, ECDSA support is planned for the future.
 The certificate must also have the Key Usage of `Digital Signature (80)` and Enhanced Key Usage `Code Signing (1.3.6.1.5.5.7.3.3)` for it to be used with Authenticode.
 
 By default authentication relies on the lookup behaviour of [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet).
@@ -75,16 +75,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Vault
-The name of the Azure KeyVault to find the certificate in.
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
 
 ```yaml
-Type: String
+Type: ActionPreference
 Parameter Sets: (All)
-Aliases: VaultName
+Aliases: proga
 
-Required: True
-Position: 0
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -103,11 +103,26 @@ Supported sources include:
 ```yaml
 Type: AzureTokenSource
 Parameter Sets: (All)
-Aliases: None
+Aliases:
 
 Required: False
 Position: Named
 Default value: Default
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Vault
+The name of the Azure KeyVault to find the certificate in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: VaultName
+
+Required: True
+Position: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -122,7 +137,7 @@ None
 
 ## OUTPUTS
 
-### OpenAuthenticode.Shared.AzureKey
+### OpenAuthenticode.Module.AzureKey
 The AzureKey object that can be used with the `-Key` parameter in `Set-OpenAuthenticodeSignature`.
 
 ## NOTES

--- a/docs/en-US/Get-OpenAuthenticodeAzTrustedSigner.md
+++ b/docs/en-US/Get-OpenAuthenticodeAzTrustedSigner.md
@@ -1,0 +1,189 @@
+---
+external help file: OpenAuthenticode.Module.dll-Help.xml
+Module Name: OpenAuthenticode
+online version: https://www.github.com/jborean93/PowerShell-OpenAuthenticode/blob/main/docs/en-US/Get-OpenAuthenticodeAzTrustedSigner.md
+schema: 2.0.0
+---
+
+# Get-OpenAuthenticodeAzTrustedSigner
+
+## SYNOPSIS
+Gets an Azure Trusted Signer key for use with Authenticode signing.
+
+## SYNTAX
+
+```
+Get-OpenAuthenticodeAzTrustedSigner [-AccountName] <String> [-ProfileName] <String> [-Endpoint] <Uri>
+ [-CorrelationId <String>] [-TokenSource <AzureTokenSource>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets an Azure Trusted Signer key from the profile and signing account name specified.
+This key can be used with [Set-OpenAuthenticodeSignature](./Set-OpenAuthenticodeSignature.md) to sign a file using the [Azure Trusted Signing service](https://learn.microsoft.com/en-us/azure/trusted-signing/overview).
+
+The authenticated Azure principal must have the following Azure access policy permissions on the requested profile certificate profile:
+
+* action - `Microsoft.CodeSigning/*/read`
+* data action - `Microsoft.CodeSigning/certificateProfiles/Sign/action`
+
+The `Trusted Signing Certificate Profile Signer` role includes these permissions.
+
+The Trusted Signing service from Azure is a convenient and cheap way for developers to sign their content using a short lived ephemeral certificate that is linked to either a verified public or private identity.
+
+By default authentication relies on the lookup behaviour of [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme?view=azure-dotnet).
+It will lookup environment variables, device managed identities, az cli contexts, etc to authenticate with Azure.
+If the [Az.Accounts](https://www.powershellgallery.com/packages/Az.Accounts/) PowerShell module has been installed, the [Connect-AzAccount](https://learn.microsoft.com/en-us/powershell/module/az.accounts/connect-azaccount?view=azps-10.2.0) cmdlet can be used to authenticate the session before this cmdlet is called.
+It has not been set to allow for interactive authentication through the web browser.
+The `-TokenSource` parameter can be used to specify different a different authentication method.
+
+See [about_AuthenticodeAzureTrustedSigning](./about_AuthenticodeAzureTrustedSigning.md) for more information on how a key can be used to sign files.
+
+## EXAMPLES
+
+### Example 1: Get key from East US endpoint
+```powershell
+PS C:\> $keyParams = @{
+    ProfileName = 'MyProfile'
+    AccountName = 'MyAccount'
+    Endpoint = 'EastUS'
+}
+PS C:\> $key = Get-OpenAuthenticodeAzTrustedSigner @keyParams
+PS C:\> Set-AuthenticodeSignature test.ps1 -Key $key
+```
+
+Gets the Azure Trusted Signing key for the certificate profile `MyProfile` in the code signing account `MyAccount` and uses it to sign the file `test.ps1`
+This does not include any pre-requisite steps for setting up the authentication details used by this cmdlet.
+
+## PARAMETERS
+
+### -AccountName
+The code signing account name that must exist in the `-Endpoint` location specified.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CorrelationId
+A string value to associate with the sign requests for future correlation.
+Support for the `-CorrelationId` may be dependent on the `-Endpoint` location specified.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Endpoint
+The Azure endpoint URL that the code signing account is located in.
+This can either by Azure URL value like `https://eus.codesigning.azure.net` or one of the human friendly names below:
+
+* `EastUS` - `https://eus.codesigning.azure.net`
+* `WestCentralUS` - `https://wcus.codesigning.azure.net`
+* `WestUS2` - `https://wus2.codesigning.azure.net`
+* `WestUS3` - `https://wus3.codesigning.azure.net`
+* `NorthEurope` - `https://neu.codesigning.azure.net`
+* `WestEurope` - `https://weu.codesigning.azure.net`
+
+This parameter supports tab completion with the known values listed above.
+
+```yaml
+Type: Uri
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProfileName
+The name of the Azure Trusted Signing certificate profile.
+This profile must exist inside the code signing account specified by `-AccountName`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenSource
+The authentication method used.
+
+Supported sources include:
+* Default - [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet)
+* Environment - [EnvironmentCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet)
+* AzurePowerShell - [AzurePowerShellCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azurepowershellcredential?view=azure-dotnet)
+* AzureCli - [AzureCliCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential?view=azure-dotnet)
+* ManagedIdentity - [ManagedIdentityCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential?view=azure-dotnet)
+
+```yaml
+Type: AzureTokenSource
+Parameter Sets: (All)
+Aliases:
+Accepted values: Default, Environment, AzurePowerShell, AzureCli, ManagedIdentity
+
+Required: False
+Position: Named
+Default value: Default
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+None
+
+## OUTPUTS
+
+### OpenAuthenticode.Module.AzureTrustedSigner
+The AzureTrustedSigner key object that can be used with the `-Key` parameter in `Set-OpenAuthenticodeSignature`.
+
+## NOTES
+As Trusted Signing uses ephemeral keys, signed PowerShell scripts using this key provider may not a viable option for people distribution modules publicly.
+This is because PowerShell also checks that the certificate's thumbprint is present in the `TrustedPeople` store which means every update would require the user to trust the certificate again.
+
+## RELATED LINKS
+
+[Azure Trusted Signing Overview](https://learn.microsoft.com/en-us/azure/trusted-signing/overview)

--- a/docs/en-US/Get-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Get-OpenAuthenticodeSignature.md
@@ -15,25 +15,29 @@ Gets information about the Authenticode signature for a file.
 ### Path (Default)
 ```
 Get-OpenAuthenticodeSignature [-Path] <String[]> [-Encoding <Encoding>] [-SkipCertificateCheck]
- [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>] [<CommonParameters>]
+ [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### LiteralPath
 ```
 Get-OpenAuthenticodeSignature -LiteralPath <String[]> [-Encoding <Encoding>] [-SkipCertificateCheck]
- [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>] [<CommonParameters>]
+ [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Content
 ```
 Get-OpenAuthenticodeSignature -Content <String> [-SkipCertificateCheck]
- [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>] [<CommonParameters>]
+ [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### RawContent
 ```
 Get-OpenAuthenticodeSignature -RawContent <Byte[]> [-Encoding <Encoding>] [-SkipCertificateCheck]
- [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>] [<CommonParameters>]
+ [-TrustStore <X509Certificate2Collection>] [-Provider <AuthenticodeProvider>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -185,6 +189,21 @@ Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
+```
+
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Provider

--- a/docs/en-US/Get-OpenAuthenticodeSslDotComKey.md
+++ b/docs/en-US/Get-OpenAuthenticodeSslDotComKey.md
@@ -16,21 +16,21 @@ Gets a SSL.com certificate key for use with Authenticode signing.
 ```
 Get-OpenAuthenticodeSslDotComKey [-ApiEndpoint <String>] [-Certificate <SslDotComCertificate>]
  [-TOPTSecret <String>] -ClientId <String> -ClientSecret <SecureString> [-AuthorizationCode <SecureString>]
- [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Credential
 ```
 Get-OpenAuthenticodeSslDotComKey [-ApiEndpoint <String>] [-Certificate <SslDotComCertificate>]
  [-TOPTSecret <String>] -ClientId <String> -ClientSecret <SecureString> -Credential <PSCredential>
- [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### UserName
 ```
 Get-OpenAuthenticodeSslDotComKey [-ApiEndpoint <String>] [-Certificate <SslDotComCertificate>]
  [-TOPTSecret <String>] -ClientId <String> -ClientSecret <SecureString> -UserName <String>
- -Password <SecureString> [<CommonParameters>]
+ -Password <SecureString> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -283,6 +283,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -TOPTSecret
 The Time-based One Time Password (TOTP) secret that can be used to generate OTP codes during signing.
 This secret is generated in the eSigner console for the certificate when setting up the second factor authentication.
@@ -326,7 +341,7 @@ None
 
 ## OUTPUTS
 
-### OpenAuthenticode.Shared.SslDotComKey
+### OpenAuthenticode.Module.SslDotComKey
 The SSL.com key object that can be used with the `-Key` parameter in `Set-OpenAuthenticodeSignature`.
 
 ## NOTES

--- a/docs/en-US/OpenAuthenticode.md
+++ b/docs/en-US/OpenAuthenticode.md
@@ -20,6 +20,9 @@ Removes all Authenticode signatures from the path specified.
 ### [Get-OpenAuthenticodeAzKey](Get-OpenAuthenticodeAzKey.md)
 Get an Azure KeyVault certificate and key for use with Authenticode signing.
 
+### [Get-OpenAuthenticodeAzTrustedSigner](Get-OpenAuthenticodeAzTrustedSigner.md)
+Gets an Azure Trusted Signer key for use with Authenticode signing.
+
 ### [Get-OpenAuthenticodeSignature](Get-OpenAuthenticodeSignature.md)
 Gets information about the Authenticode signature for a file.
 

--- a/docs/en-US/Set-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Set-OpenAuthenticodeSignature.md
@@ -17,7 +17,8 @@ Set an authenticode signature on a file.
 Set-OpenAuthenticodeSignature [-Path] <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PathKey
@@ -25,7 +26,8 @@ Set-OpenAuthenticodeSignature [-Path] <String[]> -Certificate <X509Certificate2>
 Set-OpenAuthenticodeSignature [-Path] <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### LiteralPathCertificate
@@ -33,7 +35,8 @@ Set-OpenAuthenticodeSignature [-Path] <String[]> -Key <KeyProvider> [-Encoding <
 Set-OpenAuthenticodeSignature -LiteralPath <String[]> -Certificate <X509Certificate2> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### LiteralPathKey
@@ -41,7 +44,8 @@ Set-OpenAuthenticodeSignature -LiteralPath <String[]> -Certificate <X509Certific
 Set-OpenAuthenticodeSignature -LiteralPath <String[]> -Key <KeyProvider> [-Encoding <Encoding>]
  [-HashAlgorithm <HashAlgorithmName>] [-IncludeOption <X509IncludeOption>] [-PassThru]
  [-TimeStampHashAlgorithm <HashAlgorithmName>] [-TimeStampServer <String>] [-Silent]
- [-Provider <AuthenticodeProvider>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Provider <AuthenticodeProvider>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -262,6 +266,21 @@ Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
+```
+
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Provider

--- a/docs/en-US/about_AuthenticodeAzureTrustedSigning.md
+++ b/docs/en-US/about_AuthenticodeAzureTrustedSigning.md
@@ -1,0 +1,310 @@
+# Authenticode Azure Trusted Signing
+## about_AuthenticodeAzureTrustedSigning
+
+# SHORT DESCRIPTION
+OpenAuthenticode can use the Azure Trusted Signing service to sign files using a certificate profile stored in Azure.
+These signing operations are based on a short lived certificate stored in Azure to generate an Authenticode signature used for code signing.
+It sends the data that needs to be signed, typically a hash, to the Azure API and receives the signature back from that operation.
+This guide will demonstrate how to easily set up an Azure App Principal through the Azure CLI that can be used for this operation.
+It assumes that an Azure Trusted Signing account and certificate project has been setup and associated with a validated identity.
+See [Trusted Signing overview](https://learn.microsoft.com/en-us/azure/trusted-signing/overview) for more information.
+
+# LONG DESCRIPTION
+Azure Trusted Signing is a cheap and easy way to setup a code signing certificate for Authenticode signing.
+Unlike other code signing certificate, Azure Trusted Signing uses short lived certificate (72 hour validity) to sign the content.
+This short lifetime of the certificate is a problem for PowerShell code signing at it relies on storing the certificate's thumbprint inside the `TrustedPublishers` store.
+This means that practically every new release will require the end users to re-trust the certificate if the user has enabled code signing.
+It can still be used for signing PowerShell content, as well as other Authenticode based files, but please keep in mind these limitations when it comes to PowerShell.
+A future update to PowerShell may add a way to trust a developers unique EKU id value stored in Trusted Signing certificates to solve this problem.
+
+The EKU OID used by Azure Trusted Signing starts with the prefix `1.3.6.1.4.1.311.97.` which can be used to uniquely identify a publisher across the various certificates.
+The prefix `1.3.6.1.4.1.311.97.1.3.1.` and `1.3.6.1.4.1.311.97.1.4.1.` represent a private trust identity and private trust CI policy respectively.
+See [Subscriber identity validation EKU](https://learn.microsoft.com/en-us/azure/trusted-signing/concept-trusted-signing-cert-management#subscriber-identity-validation-eku) for more information.
+
+If you wish to extract the EKU for an Authenticode signed file before trusting it in PowerShell you can use the following code:
+
+```powershell
+Function Get-AzTrustedSigningEkuOid {
+    [OutputType([PSObject])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string[]]
+        $Path
+    )
+
+    begin {
+        $ErrorActionPreference = 'Stop'
+
+        $getCommand = if (Get-Command -Name Get-OpenAuthenticodeSignature -ErrorAction SilentlyContinue) {
+            {
+                (Get-OpenAuthenticodeSignature -LiteralPath $args[0] -SkipCertificateCheck).Certificate
+            }
+        }
+        else {
+            {
+                (Get-AuthenticodeSignature -LiteralPath $args[0]).SignerCertificate
+            }
+        }
+
+        $AzTrustedSignerOid = '1.3.6.1.4.1.311.97.1.0'
+        $AzTrustedSignerOidPrefix = '1.3.6.1.4.1.311.97.'
+    }
+
+    process {
+        foreach ($p in $Path) {
+            $cert = & $getCommand $p
+
+            $ekus = $cert.Extensions | Where-Object {
+                $_ -is [System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]
+            } | Select-Object -First 1
+            if (-not $ekus) {
+                $err = [System.Management.Automation.ErrorRecord]::new(
+                    [Exception]::new("Failed to find EKU extension in '$p' signature"),
+                    "NoEkuFound",
+                    "NotSpecified",
+                    $p)
+                $PSCmdlet.WriteError($err)
+                return
+            }
+
+            $markerFound = $false
+            $idOid = $ekus.EnhancedKeyUsages.Value | ForEach-Object -Process {
+                if ($_ -eq $AzTrustedSignerOid) {
+                    $markerFound = $true
+                    return
+                }
+
+                if ($_ -like "${AzTrustedSignerOidPrefix}*") {
+                    $_
+                }
+            } | Select-Object -First 1
+
+            if (-not $markerFound) {
+                $err = [System.Management.Automation.ErrorRecord]::new(
+                    [Exception]::new("Failed to find Azure Trusted Signing EKU OID marker in '$p' signature"),
+                    "NoAzureTrustedSigningOidMarkerFound",
+                    "NotSpecified",
+                    $p)
+                $PSCmdlet.WriteError($err)
+                return
+            }
+            if (-not $idOid) {
+                $err = [System.Management.Automation.ErrorRecord]::new(
+                    [Exception]::new("Failed to find Azure Trusted Signing EKU OID publisher in '$p' signature"),
+                    "NoAzureTrustedSigningOidPublisherFound",
+                    "NotSpecified",
+                    $p)
+                $PSCmdlet.WriteError($err)
+                return
+            }
+
+            $isTrusted = $false
+            if ($PSVersionTable.PSVersion -lt '6.0' -or $IsWindows) {
+                $null = Get-ChildItem -LiteralPath Cert:\CurrentUser\TrustedPublisher | ForEach-Object -Process {
+                    $ekus = $_.Extensions | Where-Object {
+                        $_ -is [System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]
+                    } | ForEach-Object -Process {
+                        $oids = $_.EnhancedKeyUsages.Value
+
+                        if (($oids -contains $AzTrustedSignerOid) -and ($oids -contains $idOid)) {
+                            $isTrusted = $true
+                        }
+                    }
+                } | Select-Object -First 1
+            }
+
+            [PSCustomObject]@{
+                Oid = $idOid
+                IsTrusted = $isTrusted
+                Certificate = $cert
+            }
+        }
+    }
+}
+```
+
+The `Oid` property is the Azure Trusted Signing EKU OID unique for the publisher.
+The `IsTrusted` property is set to `$true` if that `Oid` is also present in an existing certificate stored in the `CurrentUser` or `LocalMachine` `TrustedPublisher` store.
+This property can be used as a way to determine if the publisher has already been trusted before and whether to re-add the new certificate into the `TrustedPublisher` store or not.
+For example this will add the certificate if the EKU OID is already trusted by another imported certificate.
+It stores the cert into the `CurrentUser` `TrustedPublisher` store but it can be changed to `Cert:\LocalMachine\TrustedPublisher` to import it machine wide for all users.
+
+```powershell
+$certInfo = Get-AzTrustedSigningEkuOid -Path script.ps1
+
+$storeName = "Cert:\CurrentUser\TrustedPublisher"
+if ($certInfo.IsTrusted -and -not (Test-Path "$storeName\$($certInfo.Certificate.Thumbprint)")) {
+    $store = Get-Item $storeName
+    $store.Open('ReadWrite')
+    $store.Add($certInfo.Certificate)
+    $store.Dispose()
+}
+```
+
+Because of the short lifespan of the certificate it should always be counter signed by a timestamp server.
+Microsoft recommend using the server `http://timestamp.acs.microsoft.com` for this purpose and can be specified through the `-TimeStampServer` parameter.
+
+To use a trusted signing profile we can create the key object from [Get-OpenAuthenticodeAzTrustedSigner](./Get-OpenAuthenticodeAzTrustedSigner.md) and use that object with the `-Key` parameter.
+
+```powershell
+# It is up to the caller to authenticate to Azure in whatever way they want.
+# In this case it'll use Connect-AzAccount but other things you can use are
+# the app client env vars or managed service identity.
+Connect-AzAccount
+
+$keyParams = @{
+    AccountName = 'MySigningAccount'
+    ProfileName = 'MyProfile'
+    Endpoint    = 'EastUS'
+}
+$key = Get-OpenAuthenticodeAzTrustedSigning @keyParams
+
+$signParams = @{
+    Key             = $key
+    TimeStampServer = 'http://timestamp.acs.microsoft.com'
+    HashAlgorithm   = 'SHA256'
+}
+Set-OpenAuthenticodeSignature -FilePath $path @signParams
+```
+
+In this example we are authenticating to the Azure API with `Connect-AzAccount` which is one of the locations our Azure REST client will use for authentication.
+From there we are retrieving a reference to the Azure Trusted Signing certificate profile to use for the signing operation.
+
+If using GitHub Actions it is possible to be able to use [Open ID Connect](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc) (`OIDC`) for authentication.
+It is highly recommended to use `OIDC` when available as the client secret does not need to be stored in the repo.
+GitHub will use `OIDC` to generate a short lived authentication token using the grants given to the service principal.
+The following code can be used to add a federated credential that gives access to a GitHub Action workflow running on the `main` branch of the repo.
+The app principal specified by `APP_NAME` still needs to have permissions to perform the signing operations.
+
+```bash
+# The name of the app principal to add the federated credential for
+APP_NAME="..."
+
+# The GitHub username the repo is in
+GH_USER="..."
+
+# The GitHub repo name for the user specified
+GH_REPO="..."
+
+# The GitHub repo branch to grant access to
+GH_BRANCH="main"
+
+OBJECT_ID="$(
+    az ad app list \
+        --display-name "${APP_NAME}" |
+    jq -r '.[].id'
+)"
+
+az ad app federated-credential create \
+    --id "${OBJECT_ID}" \
+    --parameters @- << EOF
+{
+    "name": "OpenAuthenticode-${GH_USER}-${GH_REPO}-Branch-${GH_BRANCH}",
+    "issuer": "https://token.actions.githubusercontent.com",
+    "subject": "repo:${GH_USER}/${GH_REPO}:ref:refs/heads/${GH_BRANCH}",
+    "description": "GitHub Actions OpenAuthenticode for git@github.com:${GH_USER}/${GH_REPO} refs/heads/${GH_BRANCH}",
+    "audiences": [
+        "api://AzureADTokenExchange"
+    ]
+}
+EOF
+```
+
+It is possible to setup a federated credential with a tag, environment, or pull request, see [GitHub Actions federated identity](https://learn.microsoft.com/en-us/azure/active-directory/workload-identities/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp#github-actions) for more details.
+There is currently a limit of 20 federated credentials per principal, simply create a new principal if this limit is reached.
+Once the federated credential has been created it can be used in GitHub Actions like the following:
+
+```yaml
+...
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Azure OIDC authentication
+      id-token: write
+      # Needed to checkout repository
+      contents: read
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: OIDC Login to Azure
+      if: github.ref == 'refs/heads/main'
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Sign module
+      if: github.ref == 'refs/heads/main'
+      shell: pwsh
+      run: |
+        Install-Module -Name OpenAuthenticode -Force
+        Import-Module OpenAuthenticode
+
+        $keyParams = @{
+            VaultName = '${{ secrets.AZURE_VAULT_NAME }}'
+            Certificate = '${{ secrets.AZURE_VAULT_CERT_NAME }}'
+            AccountName = '${{ secrets.AZURE_TS_NAME }}'
+            ProfileName = '${{ secrets.AZURE_TS_PROFILE }}'
+            Endpoint    = '${{ secrets.AZURE_TS_ENDPOINT }}'
+        }
+        $key = Get-OpenAuthenticodeAzTrustedSigning @keyParams
+
+        $signParams = @{
+            Key             = $key
+            TimeStampServer = 'http://timestamp.acs.microsoft.com'
+            HashAlgorithm   = 'SHA256'
+        }
+        Set-OpenAuthenticodeSignature @signParams -FilePath '...'
+...
+```
+
+The claim generated ensures only runs for commits to the `main` branch of that repo can authenticate with Azure.
+See [TestAzureCodeOIDC](https://github.com/jborean93/TestAzureCodeOIDC) for a full example of how it can be integrated.
+
+If the [Az.Accounts](https://www.powershellgallery.com/packages/Az.Accounts/) module is installed it can be used to authenticate with Azure using the parameters it exposes.
+Once authenticated, the `Get-OpenAuthenticodeAzTrustedSigner` cmdlet will reuse that authenticated context when retrieving the key.
+
+```powershell
+$connectParams = @{
+    TenantId = '...'
+    ServicePrincipal = $true
+    Credential = '..'
+}
+Connect-AzAccount @connectParams
+
+$keyParams = @{
+    AccountName = 'MySigningAccount'
+    ProfileName = 'MyProfile'
+    Endpoint    = 'EastUS'
+}
+$key = Get-OpenAuthenticodeAzTrustedSigning @keyParams
+
+$signParams = @{
+    Key             = $key
+    TimeStampServer = 'http://timestamp.acs.microsoft.com'
+    HashAlgorithm   = 'SHA256'
+}
+Set-OpenAuthenticodeSignature -FilePath $path @signParams
+```
+
+Because DefaultAzureCredential authenticates in a [pre-defined order](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) `Get-OpenAuthenticodeAzKey` may not use the expected authentication method if others are available.
+For example if a managed identity is configured on the compute resource, it will take priority over Az CLI and Azure PowerShell.
+
+This behaviour can be overwritten with the `-TokenSource` parameter of [Get-OpenAuthenticodeAzKey](./Get-OpenAuthenticodeAzKey.md).
+
+```powershell
+$keyParams = @{
+    AccountName = 'MySigningAccount'
+    ProfileName = 'MyProfile'
+    Endpoint    = 'EastUS'
+    TokenSource = 'AzurePowerhell'
+}
+$key = Get-OpenAuthenticodeAzTrustedSigning @keyParams
+```

--- a/docs/en-US/about_AuthenticodeProviders.md
+++ b/docs/en-US/about_AuthenticodeProviders.md
@@ -26,4 +26,3 @@ Each provider provides a way to:
 * Get a hashed digest in the form of the Authenticode `SpcIndirectData` structure
 * Add custom attributes to be signed to the [CmsSigner PKCS 7 block](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.pkcs.cmssigner?view=dotnet-plat-ext-7.0)
 * Save (add/remove/set) the signature to the file requested
-

--- a/module/OpenAuthenticode.psd1
+++ b/module/OpenAuthenticode.psd1
@@ -72,6 +72,7 @@
         'Add-OpenAuthenticodeSignature'
         'Clear-OpenAuthenticodeSignature'
         'Get-OpenAuthenticodeAzKey'
+        'Get-OpenAuthenticodeAzTrustedSigner'
         'Get-OpenAuthenticodeSignature'
         'Get-OpenAuthenticodeSslDotComKey'
         'Set-OpenAuthenticodeSignature'

--- a/src/OpenAuthenticode.Module/AzureEndpointCompletionsAttribute.cs
+++ b/src/OpenAuthenticode.Module/AzureEndpointCompletionsAttribute.cs
@@ -1,0 +1,121 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace OpenAuthenticode.Module;
+
+public class AzureEndpointCompletionsAttribute : IArgumentCompleter
+{
+    public static CompletionResult[] _knownEndpoints = [
+        new CompletionResult(
+            nameof(AzureEndpointTransformationAttribute.EastUS),
+            AzureEndpointTransformationAttribute.EastUSName,
+            CompletionResultType.Text,
+            AzureEndpointTransformationAttribute.EastUS),
+
+        new CompletionResult(
+            nameof(AzureEndpointTransformationAttribute.WestCentralUS),
+            AzureEndpointTransformationAttribute.WestCentralUSName,
+            CompletionResultType.Text,
+            AzureEndpointTransformationAttribute.WestCentralUS),
+
+        new CompletionResult(
+            nameof(AzureEndpointTransformationAttribute.WestUS2),
+            AzureEndpointTransformationAttribute.WestUS2Name,
+            CompletionResultType.Text,
+            AzureEndpointTransformationAttribute.WestUS2),
+
+        new CompletionResult(
+            nameof(AzureEndpointTransformationAttribute.WestUS3),
+            AzureEndpointTransformationAttribute.WestUS3Name,
+            CompletionResultType.Text,
+            AzureEndpointTransformationAttribute.WestUS3),
+
+        new CompletionResult(
+            nameof(AzureEndpointTransformationAttribute.NorthEurope),
+            AzureEndpointTransformationAttribute.NorthEuropeName,
+            CompletionResultType.Text,
+            AzureEndpointTransformationAttribute.NorthEurope),
+
+        new CompletionResult(
+            nameof(AzureEndpointTransformationAttribute.WestEurope),
+            AzureEndpointTransformationAttribute.WestEuropeName,
+            CompletionResultType.Text,
+            AzureEndpointTransformationAttribute.WestEurope),
+    ];
+
+    public static CompletionResult[] _knownEndpointsUrl = [
+        new CompletionResult(
+            AzureEndpointTransformationAttribute.EastUS,
+            AzureEndpointTransformationAttribute.EastUSName,
+            CompletionResultType.Text,
+            nameof(AzureEndpointTransformationAttribute.EastUS)),
+
+        new CompletionResult(
+            AzureEndpointTransformationAttribute.WestCentralUS,
+            AzureEndpointTransformationAttribute.WestCentralUSName,
+            CompletionResultType.Text,
+            nameof(AzureEndpointTransformationAttribute.WestCentralUS)),
+
+        new CompletionResult(
+            AzureEndpointTransformationAttribute.WestUS2,
+            AzureEndpointTransformationAttribute.WestUS2Name,
+            CompletionResultType.Text,
+            nameof(AzureEndpointTransformationAttribute.WestUS2)),
+
+        new CompletionResult(
+            AzureEndpointTransformationAttribute.WestUS3,
+            AzureEndpointTransformationAttribute.WestUS3Name,
+            CompletionResultType.Text,
+            nameof(AzureEndpointTransformationAttribute.WestUS3)),
+
+        new CompletionResult(
+            AzureEndpointTransformationAttribute.NorthEurope,
+            AzureEndpointTransformationAttribute.NorthEuropeName,
+            CompletionResultType.Text,
+            nameof(AzureEndpointTransformationAttribute.NorthEurope)),
+
+        new CompletionResult(
+            AzureEndpointTransformationAttribute.WestEurope,
+            AzureEndpointTransformationAttribute.WestEuropeName,
+            CompletionResultType.Text,
+            nameof(AzureEndpointTransformationAttribute.WestEurope)),
+    ];
+
+    public IEnumerable<CompletionResult> CompleteArgument(
+        string commandName,
+        string parameterName,
+        string wordToComplete,
+        CommandAst commandAst,
+        IDictionary fakeBoundParameters)
+    {
+        if (string.IsNullOrWhiteSpace(wordToComplete))
+        {
+            wordToComplete = "";
+        }
+
+        WildcardPattern wildcardPattern = new($"{wordToComplete}*", WildcardOptions.IgnoreCase);
+
+        if (wordToComplete.StartsWith("https://", System.StringComparison.OrdinalIgnoreCase))
+        {
+            foreach (CompletionResult completion in _knownEndpointsUrl)
+            {
+                if (wildcardPattern.IsMatch(completion.CompletionText) || wildcardPattern.IsMatch(completion.ToolTip))
+                {
+                    yield return completion;
+                }
+            }
+
+            yield break;
+        }
+
+        foreach (CompletionResult completion in _knownEndpoints)
+        {
+            if (wildcardPattern.IsMatch(completion.CompletionText) || wildcardPattern.IsMatch(completion.ToolTip))
+            {
+                yield return completion;
+            }
+        }
+    }
+}

--- a/src/OpenAuthenticode.Module/AzureEndpointTransformationAttribute.cs
+++ b/src/OpenAuthenticode.Module/AzureEndpointTransformationAttribute.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Management.Automation;
+
+namespace OpenAuthenticode.Module;
+
+public sealed class AzureEndpointTransformationAttribute : ArgumentTransformationAttribute
+{
+    public const string EastUS = "https://eus.codesigning.azure.net";
+    public const string EastUSName = "East US";
+
+    public const string WestCentralUS = "https://wcus.codesigning.azure.net";
+    public const string WestCentralUSName = "West Central US";
+
+    public const string WestUS2 = "https://wus2.codesigning.azure.net";
+    public const string WestUS2Name = "West US 2";
+
+    public const string WestUS3 = "https://wus3.codesigning.azure.net";
+    public const string WestUS3Name = "West US 3";
+
+    public const string NorthEurope = "https://neu.codesigning.azure.net";
+    public const string NorthEuropeName = "North Europe";
+
+    public const string WestEurope = "https://weu.codesigning.azure.net";
+    public const string WestEuropeName = "West Europe";
+
+    public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+    {
+        string value = LanguagePrimitives.ConvertTo<string>(inputData);
+        string valueUpper = value.ToUpperInvariant();
+        if (valueUpper == nameof(EastUS).ToUpperInvariant())
+        {
+            return new Uri(EastUS);
+        }
+        else if (valueUpper == nameof(WestCentralUS).ToUpperInvariant())
+        {
+            return new Uri(WestCentralUS);
+        }
+        else if (valueUpper == nameof(WestUS2).ToUpperInvariant())
+        {
+            return new Uri(WestUS2);
+        }
+        else if (valueUpper == nameof(WestUS3).ToUpperInvariant())
+        {
+            return new Uri(WestUS3);
+        }
+        else if (valueUpper == nameof(NorthEurope).ToUpperInvariant())
+        {
+            return new Uri(NorthEurope);
+        }
+        else if (valueUpper == nameof(WestEurope).ToUpperInvariant())
+        {
+            return new Uri(WestEurope);
+        }
+
+        return inputData;
+    }
+}

--- a/src/OpenAuthenticode.Module/AzureKeyVault.cs
+++ b/src/OpenAuthenticode.Module/AzureKeyVault.cs
@@ -6,7 +6,7 @@ using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
 public sealed class AzureKey : KeyProvider, IDisposable
 {
@@ -99,65 +99,20 @@ public sealed class AzureKey : KeyProvider, IDisposable
     ~AzureKey() => Dispose();
 }
 
-internal sealed class AzureKeyVaultRSAKey : RSA
+internal sealed class AzureKeyVaultRSAKey : AzureRSAKey
 {
     private readonly CryptographyClient _client;
-
-    private readonly static byte[] _rsaSha1Digest = new byte[] {
-        0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E,
-        0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14,
-    };
 
     public AzureKeyVaultRSAKey(CryptographyClient client)
     {
         _client = client;
     }
 
-    public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+    public override byte[] SignHashCore(byte[] hash, string azureAlgorithm)
     {
-        if (padding.Mode != RSASignaturePaddingMode.Pkcs1)
-        {
-            throw new CryptographicException($"Unsupported padding mode {padding.Mode}");
-        }
 
-        AzureSignatureAlgorithm sigAlgo;
-        if (hashAlgorithm == HashAlgorithmName.SHA1)
-        {
-            hash = CreateRSASha1Digest(hash);
-            sigAlgo = new AzureSignatureAlgorithm("RSNULL");
-        }
-        else if (hashAlgorithm == HashAlgorithmName.SHA256)
-        {
-            sigAlgo = AzureSignatureAlgorithm.RS256;
-        }
-        else if (hashAlgorithm == HashAlgorithmName.SHA384)
-        {
-            sigAlgo = AzureSignatureAlgorithm.RS384;
-        }
-        else if (hashAlgorithm == HashAlgorithmName.SHA512)
-        {
-            sigAlgo = AzureSignatureAlgorithm.RS512;
-        }
-        else
-        {
-            string msg = "Support for the hash algorithm requested '{0}' for this RSA key has not been implemented";
-            throw new CryptographicException(string.Format(msg, hashAlgorithm.Name));
-        }
-
+        AzureSignatureAlgorithm sigAlgo = new(azureAlgorithm);
         return _client.Sign(sigAlgo, hash).Signature;
-    }
-
-    public override RSAParameters ExportParameters(bool includePrivateParameters) => throw new NotImplementedException();
-
-    public override void ImportParameters(RSAParameters parameters) => throw new NotImplementedException();
-
-    private static byte[] CreateRSASha1Digest(byte[] hash)
-    {
-        byte[] pkcs1Digest = new byte[_rsaSha1Digest.Length + 20];
-        _rsaSha1Digest.CopyTo(pkcs1Digest, 0);
-        hash.CopyTo(pkcs1Digest, _rsaSha1Digest.Length);
-
-        return pkcs1Digest;
     }
 }
 

--- a/src/OpenAuthenticode.Module/AzureRSAKey.cs
+++ b/src/OpenAuthenticode.Module/AzureRSAKey.cs
@@ -1,0 +1,62 @@
+
+using System;
+using System.Security.Cryptography;
+
+namespace OpenAuthenticode.Module;
+
+internal abstract class AzureRSAKey : RSA
+{
+    private readonly static byte[] _rsaSha1Digest = [
+        0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E,
+        0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14,
+    ];
+
+    public abstract byte[] SignHashCore(byte[] hash, string azureAlgorithm);
+
+    public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+    {
+        if (padding.Mode != RSASignaturePaddingMode.Pkcs1)
+        {
+            throw new CryptographicException($"Unsupported padding mode {padding.Mode}");
+        }
+
+        string azureAlgo;
+        if (hashAlgorithm == HashAlgorithmName.SHA1)
+        {
+            hash = CreateRSASha1Digest(hash);
+            azureAlgo = "RSNULL";
+        }
+        else if (hashAlgorithm == HashAlgorithmName.SHA256)
+        {
+            azureAlgo = "RS256";
+        }
+        else if (hashAlgorithm == HashAlgorithmName.SHA384)
+        {
+            azureAlgo = "RS384";
+        }
+        else if (hashAlgorithm == HashAlgorithmName.SHA512)
+        {
+            azureAlgo = "RS512";
+        }
+        else
+        {
+            string msg = "Support for the hash algorithm requested '{0}' for this RSA key has not been implemented";
+            throw new CryptographicException(string.Format(msg, hashAlgorithm.Name));
+        }
+
+        return SignHashCore(hash, azureAlgo);
+    }
+
+    public override RSAParameters ExportParameters(bool includePrivateParameters) => throw new NotImplementedException();
+
+    public override void ImportParameters(RSAParameters parameters) => throw new NotImplementedException();
+
+    private static byte[] CreateRSASha1Digest(byte[] hash)
+    {
+        byte[] pkcs1Digest = new byte[_rsaSha1Digest.Length + 20];
+        _rsaSha1Digest.CopyTo(pkcs1Digest, 0);
+        hash.CopyTo(pkcs1Digest, _rsaSha1Digest.Length);
+
+        return pkcs1Digest;
+    }
+}

--- a/src/OpenAuthenticode.Module/AzureTokenSource.cs
+++ b/src/OpenAuthenticode.Module/AzureTokenSource.cs
@@ -1,29 +1,27 @@
+using System;
 using Azure.Core;
 using Azure.Identity;
 
-namespace OpenAuthenticode.Shared {
-    public enum AzureTokenSource {
-        Default,
-        Environment,
-        AzurePowerShell,
-        AzureCli,
-        ManagedIdentity,
-    }
+namespace OpenAuthenticode.Module;
 
-    public class TokenCredentialBuilder {
-        public static TokenCredential GetTokenCredential(AzureTokenSource tokenSource) {
-            switch(tokenSource) {
-                case AzureTokenSource.Environment:
-                    return new EnvironmentCredential();
-                case AzureTokenSource.AzurePowerShell:
-                    return new AzurePowerShellCredential();
-                case AzureTokenSource.AzureCli:
-                    return new AzureCliCredential();
-                case AzureTokenSource.ManagedIdentity:
-                    return new ManagedIdentityCredential();
-                default:
-                    return new DefaultAzureCredential(includeInteractiveCredentials: false);
-            }
-        }
-    }
+public enum AzureTokenSource
+{
+    Default,
+    Environment,
+    AzurePowerShell,
+    AzureCli,
+    ManagedIdentity,
+}
+
+public static class TokenCredentialBuilder
+{
+    public static TokenCredential GetTokenCredential(AzureTokenSource tokenSource) => tokenSource switch
+    {
+        AzureTokenSource.Default => new DefaultAzureCredential(includeInteractiveCredentials: false),
+        AzureTokenSource.Environment => new EnvironmentCredential(),
+        AzureTokenSource.AzurePowerShell => new AzurePowerShellCredential(),
+        AzureTokenSource.AzureCli => new AzureCliCredential(),
+        AzureTokenSource.ManagedIdentity => new ManagedIdentityCredential(),
+        _ => throw new NotImplementedException($"Unknown AzureTokenSource {tokenSource} specified."),
+    };
 }

--- a/src/OpenAuthenticode.Module/AzureTrustedSigner.cs
+++ b/src/OpenAuthenticode.Module/AzureTrustedSigner.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Azure.CodeSigning;
+using Azure.CodeSigning.Models;
+using AzureSignatureAlgorithm = Azure.CodeSigning.Models.SignatureAlgorithm;
+
+namespace OpenAuthenticode.Module;
+
+public sealed class AzureTrustedSigner : KeyProvider, IDisposable
+{
+    private readonly CertificateProfileClient _client;
+
+    public override X509Certificate2 Certificate { get; }
+
+    internal override AsymmetricAlgorithm Key { get; }
+
+    internal override HashAlgorithmName? DefaultHashAlgorithm { get; }
+
+    public AzureTrustedSigner(
+        CertificateProfileClient client,
+        X509Certificate2 cert,
+        string accountName,
+        string profileName,
+        string? correlationId)
+    {
+        _client = client;
+        Certificate = cert;
+
+        using RSA rsaPubKey = cert.GetRSAPublicKey()
+            ?? throw new NotImplementedException("The Azure Trusted Signer key implementation currently only supports RSA keys.");
+        Key = new AzureTrustedSignerRSAKey(_client, accountName, profileName, correlationId);
+    }
+
+    public void Dispose()
+    {
+        Key?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+    ~AzureTrustedSigner() => Dispose();
+}
+
+internal sealed class AzureTrustedSignerRSAKey : AzureRSAKey
+{
+    private readonly CertificateProfileClient _client;
+    private readonly string _accountName;
+    private readonly string _profileName;
+    private readonly string? _correlationId;
+
+    public AzureTrustedSignerRSAKey(
+        CertificateProfileClient client,
+        string accountName,
+        string profileName,
+        string? correlationId = null)
+    {
+        _client = client;
+        _accountName = accountName;
+        _profileName = profileName;
+        _correlationId = correlationId;
+    }
+
+    public override byte[] SignHashCore(byte[] hash, string azureAlgorithm)
+    {
+        AzureSignatureAlgorithm sigAlgo = new(azureAlgorithm);
+
+        SignRequest request = new(sigAlgo, hash);
+        CertificateProfileSignOperation operation = _client.StartSign(
+            codeSigningAccountName: _accountName,
+            certificateProfileName: _profileName,
+            body: request,
+            xCorrelationId: _correlationId);
+        SignStatus response = operation.WaitForCompletionAsync().GetAwaiter().GetResult();
+
+        return response.Signature;
+    }
+}

--- a/src/OpenAuthenticode.Module/CscApi.cs
+++ b/src/OpenAuthenticode.Module/CscApi.cs
@@ -11,7 +11,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
 // https://cloudsignatureconsortium.org/wp-content/uploads/2020/05/CSC_API_V0_0.1.7.9.pdf
 

--- a/src/OpenAuthenticode.Module/EncodingTransformationAttribute.cs
+++ b/src/OpenAuthenticode.Module/EncodingTransformationAttribute.cs
@@ -3,9 +3,9 @@ using System.Management.Automation;
 using System.Text;
 using System.Globalization;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
-public sealed class EncodingTransformAttribute : ArgumentTransformationAttribute
+public sealed class EncodingTransformationAttribute : ArgumentTransformationAttribute
 {
     public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
     {

--- a/src/OpenAuthenticode.Module/OpenAuthenticode.Module.csproj
+++ b/src/OpenAuthenticode.Module/OpenAuthenticode.Module.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
+    <PackageReference Include="Azure.CodeSigning.Sdk" Version="0.1.127" />
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />

--- a/src/OpenAuthenticode.Module/OpenAuthenticodeAzKey.cs
+++ b/src/OpenAuthenticode.Module/OpenAuthenticodeAzKey.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Management.Automation;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
 [Cmdlet(VerbsCommon.Get, "OpenAuthenticodeAzKey")]
 [OutputType(typeof(AzureKey))]
@@ -15,7 +15,7 @@ public sealed class GetOpenAuthenticodeAzKey : PSCmdlet
     [Alias("CertificateName")]
     public string Certificate { get; set; } = "";
 
-    [Parameter()]
+    [Parameter]
     public AzureTokenSource TokenSource { get; set; } = AzureTokenSource.Default;
 
     protected override void ProcessRecord()

--- a/src/OpenAuthenticode.Module/OpenAuthenticodeAzTrustedSigner.cs
+++ b/src/OpenAuthenticode.Module/OpenAuthenticodeAzTrustedSigner.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Management.Automation;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Azure;
+using Azure.CodeSigning;
+
+namespace OpenAuthenticode.Module;
+
+[Cmdlet(VerbsCommon.Get, "OpenAuthenticodeAzTrustedSigner")]
+[OutputType(typeof(AzureTrustedSigner))]
+public sealed class GetOpenAuthenticodeAzTrustedSigner : AsyncPSCmdlet
+{
+    [Parameter(
+        Mandatory = true,
+        Position = 0
+    )]
+    public string AccountName { get; set; } = default!;
+
+    [Parameter(
+        Mandatory = true,
+        Position = 1
+    )]
+    public string ProfileName { get; set; } = default!;
+
+    [Parameter(
+        Mandatory = true,
+        Position = 2
+    )]
+    [ArgumentCompleter(typeof(AzureEndpointCompletionsAttribute))]
+    [AzureEndpointTransformation]
+    public Uri Endpoint { get; set; } = default!;
+
+    [Parameter]
+    public string? CorrelationId { get; set; }
+
+    [Parameter()]
+    public AzureTokenSource TokenSource { get; set; } = AzureTokenSource.Default;
+
+    protected override async Task ProcessRecordAsync()
+    {
+        Debug.Assert(AccountName != null);
+        Debug.Assert(ProfileName != null);
+        Debug.Assert(Endpoint != null);
+
+        CertificateProfileClientOptions options = new();
+        options.Diagnostics.IsLoggingContentEnabled = false;
+        options.Diagnostics.IsLoggingEnabled = false;
+        options.Diagnostics.IsTelemetryEnabled = false;
+        var cred = TokenCredentialBuilder.GetTokenCredential(TokenSource);
+        CertificateProfileClient client = new(cred, endpoint: Endpoint, options: options);
+
+        byte[] rawChain;
+        try
+        {
+            WriteVerbose($"Getting certificate chain from Azure Code Signing service for {AccountName} {ProfileName} at {Endpoint}");
+            Response<Stream> chainResponse = await client.GetSignCertificateChainAsync(
+                codeSigningAccountName: AccountName,
+                certificateProfileName: ProfileName,
+                cancellationToken: CancelToken).ConfigureAwait(false);
+
+            rawChain = new byte[chainResponse.Value.Length];
+            await chainResponse.Value.CopyToAsync(
+                new MemoryStream(rawChain)).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            ErrorRecord err = new(
+                e,
+                "AzTrustedSignerKeyError",
+                ErrorCategory.NotSpecified,
+                null);
+            WriteError(err);
+            return;
+        }
+
+        WriteVerbose("Importing certificate chain");
+        X509Certificate2Collection chain = new();
+        chain.Import(rawChain);
+        X509Certificate2 cert = chain[0];
+        WriteVerbose($"Creating AzureTrustedSigner object with cert '{cert.SubjectName.Name}' - {cert.Thumbprint}");
+
+        AzureTrustedSigner signerKey = new(
+            client,
+            cert,
+            AccountName,
+            ProfileName,
+            CorrelationId);
+        WriteObject(signerKey);
+    }
+}

--- a/src/OpenAuthenticode.Module/OpenAuthenticodeSignature.cs
+++ b/src/OpenAuthenticode.Module/OpenAuthenticodeSignature.cs
@@ -12,7 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.Commands;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
 public class OpenAuthenticodeSignatureBase : AsyncPSCmdlet
 {
@@ -104,7 +104,7 @@ public sealed class ClearOpenAuthenticodeSignature : OpenAuthenticodeSignatureBa
     }
 
     [Parameter()]
-    [EncodingTransformAttribute]
+    [EncodingTransformation]
     [ArgumentCompletions("Utf8", "ASCII", "ANSI", "OEM", "Unicode", "Utf8Bom", "Utf8NoBom")]
     public Encoding? Encoding { get; set; }
 
@@ -216,7 +216,7 @@ public sealed class GetOpenAuthenticodeSignature : OpenAuthenticodeSignatureBase
     [Parameter(ParameterSetName = "Path")]
     [Parameter(ParameterSetName = "LiteralPath")]
     [Parameter(ParameterSetName = "RawContent")]
-    [EncodingTransformAttribute]
+    [EncodingTransformation]
     [ArgumentCompletions("Utf8", "ASCII", "ANSI", "OEM", "Unicode", "Utf8Bom", "Utf8NoBom")]
     public Encoding? Encoding { get; set; }
 
@@ -443,7 +443,7 @@ public abstract class AddSetOpenAuthenticodeSignature : OpenAuthenticodeSignatur
     public KeyProvider? Key { get; set; }
 
     [Parameter()]
-    [EncodingTransformAttribute]
+    [EncodingTransformation]
     [ArgumentCompletions("Utf8", "ASCII", "ANSI", "OEM", "Unicode", "Utf8Bom", "Utf8NoBom")]
     public Encoding? Encoding { get; set; }
 

--- a/src/OpenAuthenticode.Module/OpenAuthenticodeSslDotComKey.cs
+++ b/src/OpenAuthenticode.Module/OpenAuthenticodeSslDotComKey.cs
@@ -12,7 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
 [Cmdlet(
     VerbsCommon.Get,

--- a/src/OpenAuthenticode.Module/SslDotCom.cs
+++ b/src/OpenAuthenticode.Module/SslDotCom.cs
@@ -9,7 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using OtpNet;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
 public sealed class SslDotComKey : KeyProvider
 {

--- a/src/OpenAuthenticode.Module/StringAsSecureStringTransformer.cs
+++ b/src/OpenAuthenticode.Module/StringAsSecureStringTransformer.cs
@@ -1,7 +1,7 @@
 using System.Management.Automation;
 using System.Security;
 
-namespace OpenAuthenticode.Shared;
+namespace OpenAuthenticode.Module;
 
 internal sealed class StringAsSecureStringTransformer : ArgumentTransformationAttribute
 {

--- a/tests/Get-OpenAuthenticodeAzKey.Tests.ps1
+++ b/tests/Get-OpenAuthenticodeAzKey.Tests.ps1
@@ -71,18 +71,6 @@ Describe "Get-OpenAuthenticodeAzKey" -Skip:(-not (Test-Available)) {
         if ($ecdsaP521Key) { $ecdsaP521Key.Dispose() }
     }
 
-    It "Builds credential for token source <Name>" -TestCases (
-            [OpenAuthenticode.Shared.AzureTokenSource].GetEnumValues() | ForEach-Object {
-                @{
-                    Name = $_.ToString()
-                    TokenSource = $_
-                }
-            }
-        ) {
-        param($Name, $TokenSource)
-        [OpenAuthenticode.Shared.TokenCredentialBuilder]::GetTokenCredential($TokenSource) | Should -Not -BeNullOrEmpty
-    }
-
     It "Signs with RSA key and hash <Name>" -TestCases @(
         @{ Name = "Default" }
         @{ Name = "SHA1" }

--- a/tests/Get-OpenAuthenticodeAzTrustedSigner.Tests.ps1
+++ b/tests/Get-OpenAuthenticodeAzTrustedSigner.Tests.ps1
@@ -1,0 +1,90 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+Function Test-Available {
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param ()
+
+    if (
+        $env:AZURE_TENANT_ID -and
+        (
+            (
+                $env:AZURE_CONNECT_APPLICATION -and
+                (Get-Command -Name Connect-AzAccount -ErrorAction SilentlyContinue)
+            ) -or
+            (
+                $env:AZURE_CLIENT_ID -and
+                (
+                    $env:AZURE_CLIENT_SECRET -or
+                    $env:AZURE_CLIENT_CERTIFICATE_PATH
+                )
+            ) -or
+            $env:AZURE_TOKEN_SOURCE
+        ) -and
+        $env:AZURE_TRUSTED_SIGNER_ACCOUNT -and
+        $env:AZURE_TRUSTED_SIGNER_PROFILE -and
+        $env:AZURE_TRUSTED_SIGNER_ENDPOINT
+
+    ) {
+        $true
+    }
+    else {
+        $false
+    }
+}
+
+Describe "Get-OpenAuthenticodeAzTrustedSigner" -Skip:(-not (Test-Available)) {
+    BeforeAll {
+        if ($env:AZURE_CONNECT_APPLICATION -and (Get-Command -Name Connect-AzAccount -ErrorAction SilentlyContinue)) {
+            Connect-AzAccount -TenantId $env:AZURE_TENANT_ID
+        }
+
+        $keyParams = @{
+            AccountName = $env:AZURE_TRUSTED_SIGNER_ACCOUNT
+            ProfileName = $env:AZURE_TRUSTED_SIGNER_PROFILE
+            Endpoint = $env:AZURE_TRUSTED_SIGNER_ENDPOINT
+        }
+        if($env:AZURE_TOKEN_SOURCE) {
+            $keyParams.TokenSource = $env:AZURE_TOKEN_SOURCE
+        }
+        $key = Get-OpenAuthenticodeAzTrustedSigner @keyParams
+    }
+    AfterAll {
+        if ($key) { $key.Dispose() }
+    }
+
+    It "Signs with RSA key and hash <Name>" -TestCases @(
+        @{ Name = "Default" }
+        @{ Name = "SHA256" }
+        @{ Name = "SHA384" }
+        @{ Name = "SHA512" }
+    ) {
+        param ($Name)
+
+        if (-not $key) {
+            Set-ItResult -Skipped -Because "Env var AZURE_TRUSTED_SIGNER_ACCOUNT or AZURE_TRUSTED_SIGNER_PROFILE or AZURE_TRUSTED_SIGNER_ENDPOINT is not set"
+        }
+
+        $scriptPath = New-Item -Path temp: -Name script.ps1 -Force -Value "Write-Host test`r`n"
+        $setParams = @{
+            Path = $scriptPath
+            Key = $key
+        }
+        if ($Name -eq "Default") {
+            $Name = "SHA256"
+        }
+        else {
+            $setParams.HashAlgorithm = $Name
+        }
+        Set-OpenAuthenticodeSignature @setParams
+
+        $actual = Get-OpenAuthenticodeSignature -Path $scriptPath -SkipCertificateCheck
+        $actual.HashAlgorithm | Should -Be $Name
+        $actual.Certificate.GetKeyAlgorithm() | Should -Be "1.2.840.113549.1.1.1"  # RSA
+
+        If (Get-Command -Name Get-AuthenticodeSignature -ErrorAction Ignore) {
+            $actual = Get-AuthenticodeSignature -FilePath $scriptPath.FullName
+            $actual.Status | Should -Not -Be HashMismatch
+        }
+    }
+}


### PR DESCRIPTION
Adds supprot for using Azure Trusted Signing to sign the data needed. This service is provided by Azure and uses ephemeral certificates tied to a verified account.

Also includes some cleanup of the code like fixing up the namedspace of the ALC'd module and other tiny changes.