### PR TITLE
Add better error for invalid Azure endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for OpenAuthenticode
 
+## v0.6.3 - 2025-09-12
+
+* Provide better when an invalid URI was specified for `Get-OpenAuthenticodeAzTrustedSigner -Endpoint`
+
 ## v0.6.2 - 2025-09-01
 
 * Update Azure dependencies to the latest versions

--- a/module/OpenAuthenticode.psd1
+++ b/module/OpenAuthenticode.psd1
@@ -14,7 +14,7 @@
     RootModule = 'OpenAuthenticode.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.6.2'
+    ModuleVersion = '0.6.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/OpenAuthenticode.Module/AzureEndpointTransformationAttribute.cs
+++ b/src/OpenAuthenticode.Module/AzureEndpointTransformationAttribute.cs
@@ -52,6 +52,20 @@ public sealed class AzureEndpointTransformationAttribute : ArgumentTransformatio
             return new Uri(WestEurope);
         }
 
-        return inputData;
+        if (Uri.TryCreate(value, UriKind.Absolute, out Uri? endpointUri))
+        {
+            return endpointUri;
+        }
+
+        string wellKnownIds = string.Join(", ", [
+            nameof(EastUS),
+            nameof(WestCentralUS),
+            nameof(WestUS2),
+            nameof(WestUS3),
+            nameof(NorthEurope),
+            nameof(WestEurope)
+        ]);
+        throw new ArgumentTransformationMetadataException(
+            $"The endpoint value '{value}' must either be a well known endpoint identifier {wellKnownIds}, or an absolute URI to an Azure endpoint.");
     }
 }

--- a/tests/Get-OpenAuthenticodeAzTrustedSigner.Tests.ps1
+++ b/tests/Get-OpenAuthenticodeAzTrustedSigner.Tests.ps1
@@ -33,6 +33,14 @@ Function Test-Available {
     }
 }
 
+Describe "Get-OpenauthenticodeAzTrustedSigner - no connection" {
+    It "Throws error when using -Endpoint that is not an absolute URI or well known ID" {
+        {
+            Get-OpenAuthenticodeAzTrustedSigner -Endpoint abc
+        } | Should -Throw "*The endpoint value 'abc' must either be a well known endpoint identifier *, or an absolute URI to an Azure endpoint*"
+    }
+}
+
 Describe "Get-OpenAuthenticodeAzTrustedSigner" -Skip:(-not (Test-Available)) {
     BeforeAll {
         if ($env:AZURE_CONNECT_APPLICATION -and (Get-Command -Name Connect-AzAccount -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
Adds a better error message when `Get-OpenAuthenticodeAzTrustedSigner` is used with an `-Endpoint` that is not one of the well known endpoint identifiers or not an absolute URI. Without this the error message from the Azure SDK is not very easy to understand.