### PR TITLE
Add support for `.cdxml` and `.mof`

### DIFF
--- a/docs/en-US/Add-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Add-OpenAuthenticodeSignature.md
@@ -284,14 +284,15 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
-* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
+* `PowerShellMof` - Uses the PowerShell script Authenticode provider for MOF files like `.mof`
+* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1`, `.ps1xml`, and `.cdxml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml
 Type: AuthenticodeProvider
 Parameter Sets: (All)
 Aliases:
-Accepted values: NotSpecified, PowerShell, PowerShellXml, PEBinary
+Accepted values: NotSpecified, PowerShell, PowerShellMof, PowerShellXml, PEBinary
 
 Required: False
 Position: Named

--- a/docs/en-US/Clear-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Clear-OpenAuthenticodeSignature.md
@@ -142,14 +142,15 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
-* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
+* `PowerShellMof` - Uses the PowerShell script Authenticode provider for MOF files like `.mof`
+* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1`, `.ps1xml`, and `.cdxml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml
 Type: AuthenticodeProvider
 Parameter Sets: (All)
 Aliases:
-Accepted values: NotSpecified, PowerShell, PowerShellXml, PEBinary
+Accepted values: NotSpecified, PowerShell, PowerShellMof, PowerShellXml, PEBinary
 
 Required: False
 Position: Named

--- a/docs/en-US/Get-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Get-OpenAuthenticodeSignature.md
@@ -216,14 +216,15 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
-* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
+* `PowerShellMof` - Uses the PowerShell script Authenticode provider for MOF files like `.mof`
+* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1`, `.ps1xml`, and `.cdxml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml
 Type: AuthenticodeProvider
 Parameter Sets: (All)
 Aliases:
-Accepted values: NotSpecified, PowerShell, PowerShellXml, PEBinary
+Accepted values: NotSpecified, PowerShell, PowerShellMof, PowerShellXml, PEBinary
 
 Required: False
 Position: Named

--- a/docs/en-US/Set-OpenAuthenticodeSignature.md
+++ b/docs/en-US/Set-OpenAuthenticodeSignature.md
@@ -291,14 +291,15 @@ Valid providers are:
 
 * `NotSpecified` - Uses the file extension to find the provider
 * `PowerShell` - Uses the PowerShell script Authenticode provider
-* `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1` and `.ps1xml`
++ `PowerShellMof` - Uses the PowerShell script Authenticode provider for MOF files like `.mof`
++ `PowerShellXml` - Uses the PowerShell script Authenticode provider for XML files like `.psc1`, `.ps1xml`, and `.cdxml`
 * `PEBinary` - Windows `.exe`, `.dll` files, including cross platform dotnet assemblies
 
 ```yaml
 Type: AuthenticodeProvider
 Parameter Sets: (All)
 Aliases:
-Accepted values: NotSpecified, PowerShell, PowerShellXml, PEBinary
+Accepted values: NotSpecified, PowerShell, PowerShellMof, PowerShellXml, PEBinary
 
 Required: False
 Position: Named

--- a/docs/en-US/about_AuthenticodeProviders.md
+++ b/docs/en-US/about_AuthenticodeProviders.md
@@ -11,7 +11,8 @@ Currently the following providers have been implemented in this module.
 |Provider|File Extensions|String Contents|
 |-|-|-|
 |PowerShell|`.ps1`, `.psd1`, `.psm1`|Yes|
-|PowerShellXml|`.psc1`, `.ps1xml`|Yes|
+|PowerShellMof|`.mof`|Yes|
+|PowerShellXml|`.psc1`, `.ps1xml`, `.cdxml`|Yes|
 |PEBinary|`.dll`, `.exe`|No|
 
 The `Get-OpenAuthenticodeSignature`, `Set-OpenAuthenticodeSignature`, and `Add-OpenAuthenticodeSignature` uses the extension on the file path provided to determine what provider to use.

--- a/src/OpenAuthenticode/IAuthenticodeProvider.cs
+++ b/src/OpenAuthenticode/IAuthenticodeProvider.cs
@@ -67,6 +67,9 @@ internal static class ProviderFactory
         RegisterProvider(AuthenticodeProvider.PowerShell,
             PowerShellScriptProvider.FileExtensions,
             PowerShellScriptProvider.Create);
+        RegisterProvider(AuthenticodeProvider.PowerShellMof,
+            PowerShellMofProvider.FileExtensions,
+            PowerShellMofProvider.Create);
         RegisterProvider(AuthenticodeProvider.PowerShellXml,
             PowerShellXmlProvider.FileExtensions,
             PowerShellXmlProvider.Create);
@@ -150,6 +153,7 @@ public enum AuthenticodeProvider
 {
     NotSpecified,
     PowerShell,
+    PowerShellMof,
     PowerShellXml,
     PEBinary,
 }

--- a/src/OpenAuthenticode/PowerShellScriptProvider.cs
+++ b/src/OpenAuthenticode/PowerShellScriptProvider.cs
@@ -260,14 +260,35 @@ internal class PowerShellScriptProvider : PowerShellProvider
 }
 
 /// <summary>
+/// Authenticode providers for PowerShell MOF files. This includes files
+/// with the extension <c>.mof</c>.
+/// </summary>
+internal class PowerShellMofProvider : PowerShellProvider
+{
+    public override AuthenticodeProvider Provider => AuthenticodeProvider.PowerShellMof;
+
+    internal static string[] FileExtensions => new[] { ".mof" };
+
+    protected override string StartComment => "/* ";
+
+    protected override string EndComment => " */";
+
+    public static PowerShellMofProvider Create(byte[] data, Encoding? fileEncoding)
+        => new PowerShellMofProvider(data, fileEncoding ?? GetScriptEncoding(data));
+
+    private PowerShellMofProvider(byte[] data, Encoding fileEncoding) : base(data, fileEncoding)
+    { }
+}
+
+/// <summary>
 /// Authenticode providers for PowerShell XML files. This includes files
-/// with the extensions <c>.psc1</c> and <c>.psm1xml</c>.
+/// with the extensions <c>.psc1</c>, <c>.psm1xml</c>, and <c>.cdxml</c>.
 /// </summary>
 internal class PowerShellXmlProvider : PowerShellProvider
 {
     public override AuthenticodeProvider Provider => AuthenticodeProvider.PowerShellXml;
 
-    internal static string[] FileExtensions => new[] { ".psc1", ".ps1xml" };
+    internal static string[] FileExtensions => new[] { ".psc1", ".ps1xml", ".cdxml" };
 
     protected override string StartComment => "<!-- ";
 


### PR DESCRIPTION
I was [reversing `pwrshsip.dll`](https://garden.tplant.com.au/Microsoft/Windows/PowerShell#signing) and noticed it supported `.cdxml` and `.mof`, so thought I might as well send a PR. Thanks for the great module!